### PR TITLE
Enhance package info

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Rust Linting
+name: Lint
 
 on:
   push:
@@ -39,7 +39,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: Check lint
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Check formatting
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust Tests
+name: Unit Tests
 
 on:
   push:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3960,8 +3960,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "uniswap-v3-sdk-rs"
-version = "0.6.0"
+name = "uniswap-v3-sdk"
+version = "0.6.1"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "uniswap-v3-sdk-rs"
-version = "0.6.0"
+name = "uniswap-v3-sdk"
+version = "0.6.1"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
+description = "Uniswap v3 SDK for Rust"
+license = "MIT"
 
 [dependencies]
 alloy-dyn-abi = "0.5.4"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Shuhui Luo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Uniswap V3 SDK Rust
+
+[![Unit Tests](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/workflows/Unit%20Tests/badge.svg)](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/actions?query=workflow%3A%22Unit+Tests%22)
+[![Lint](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/workflows/Lint/badge.svg)](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/actions?query=workflow%3ALint)
+
+A Rust SDK for building applications on top of Uniswap V3. Migration from the
+TypeScript [Uniswap/v3-sdk](https://github.com/Uniswap/v3-sdk).
+
+WIP.
+
+## Features
+
+- Opinionated Rust implementation of the Uniswap V3 SDK with a focus on readability and performance
+- Usage of [alloy-rs](https://github.com/alloy-rs) types
+- Reimplementation of the math libraries in [Uniswap V3 Math In Rust](https://github.com/0xKitsune/uniswap-v3-math)
+  based on optimizations presented in [Uni V3 Lib](https://github.com/Aperture-Finance/uni-v3-lib)
+- Extensive unit tests and benchmarks
+- An `extensions` module for additional functionality related to Uniswap V3
+
+## Getting started
+
+Add the following to your `Cargo.toml` file:
+
+```toml
+uniswap-v3-sdk = { git = "https://github.com/shuhuiluo/uniswap-v3-sdk-rs", branch = "master" }
+```
+
+### Usage
+
+The package structure follows that of the TypeScript SDK, but with `snake_case` instead of `camelCase`.
+
+For easy import, use the prelude:
+
+```rust
+use uniswap_v3_sdk::prelude::*;
+```
+
+## Contributing
+
+Contributions are welcome. Please open an issue if you have any questions or suggestions.
+
+### Testing
+
+Tests are run with `cargo test`. To test a specific module, use `cargo test --test <module_name>`.
+
+### Linting
+
+Linting is done with `clippy` and `rustfmt`. To run the linter,
+use `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check`.
+
+### Benchmarking
+
+Benchmarking is done with `criterion`. To run the benchmarks, use `cargo bench`.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+## Acknowledgements
+
+This project is inspired by and adapted from the following projects:
+
+- [Uniswap V3 SDK](https://github.com/Uniswap/v3-sdk)
+- [Uniswap SDK Core Rust](https://github.com/malik672/uniswap-sdk-core-rust)
+- [Uniswap V3 Math In Rust](https://github.com/0xKitsune/uniswap-v3-math)
+- [Uni V3 Lib](https://github.com/Aperture-Finance/uni-v3-lib)

--- a/benches/bit_math.rs
+++ b/benches/bit_math.rs
@@ -2,7 +2,7 @@ use alloy_primitives::U256;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::ops::Shl;
 use uniswap_v3_math::{bit_math, utils::ruint_to_u256};
-use uniswap_v3_sdk_rs::utils::{least_significant_bit, most_significant_bit};
+use uniswap_v3_sdk::utils::{least_significant_bit, most_significant_bit};
 
 fn most_significant_bit_benchmark(c: &mut Criterion) {
     c.bench_function("most_significant_bit", |b| {

--- a/benches/sqrt_price_math.rs
+++ b/benches/sqrt_price_math.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{keccak256, U256};
 use alloy_sol_types::SolValue;
 use criterion::{criterion_group, criterion_main, Criterion};
 use uniswap_v3_math::{sqrt_price_math, utils::ruint_to_u256};
-use uniswap_v3_sdk_rs::utils::{
+use uniswap_v3_sdk::utils::{
     get_amount_0_delta, get_amount_0_delta_signed, get_amount_1_delta, get_amount_1_delta_signed,
     get_next_sqrt_price_from_input, get_next_sqrt_price_from_output,
 };

--- a/benches/swap_math.rs
+++ b/benches/swap_math.rs
@@ -2,7 +2,7 @@ use alloy_primitives::{keccak256, I256, U256};
 use alloy_sol_types::SolValue;
 use criterion::{criterion_group, criterion_main, Criterion};
 use uniswap_v3_math::{swap_math, utils::ruint_to_u256};
-use uniswap_v3_sdk_rs::utils::compute_swap_step;
+use uniswap_v3_sdk::utils::compute_swap_step;
 
 fn pseudo_random(seed: u64) -> U256 {
     keccak256(seed.abi_encode()).into()

--- a/benches/tick_math.rs
+++ b/benches/tick_math.rs
@@ -2,7 +2,7 @@ use alloy_primitives::U256;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::ops::Shl;
 use uniswap_v3_math::{tick_math, utils::ruint_to_u256};
-use uniswap_v3_sdk_rs::utils::{get_sqrt_ratio_at_tick, get_tick_at_sqrt_ratio};
+use uniswap_v3_sdk::utils::{get_sqrt_ratio_at_tick, get_tick_at_sqrt_ratio};
 
 fn get_sqrt_ratio_at_tick_benchmark(c: &mut Criterion) {
     c.bench_function("get_sqrt_ratio_at_tick", |b| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,15 @@
 #![feature(int_roundings)]
 #![feature(is_sorted)]
-//! # v3-sdk-rs
+//! # uniswap-v3-sdk
 //!
-//! Migration of Uniswap V3 SDK to Rust
+//! A Rust SDK for building applications on top of Uniswap V3.
+//! Migration from the TypeScript [Uniswap/v3-sdk](https://github.com/Uniswap/v3-sdk).
 
 pub mod constants;
 pub mod entities;
 pub mod extensions;
 pub mod utils;
+
+pub mod prelude {
+    pub use crate::{constants::*, entities::*, extensions::*, utils::*};
+}

--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn test_next_initialized_tick_mid_lte_false() {
         assert_eq!(TICKS.next_initialized_tick(-1, false), &MID_TICK);
-        assert_eq!(TICKS.next_initialized_tick(0 + 1, false), &HIGH_TICK);
+        assert_eq!(TICKS.next_initialized_tick(1, false), &HIGH_TICK);
     }
 
     #[test]


### PR DESCRIPTION
This commit updates the project identity from 'uniswap-v3-sdk-rs' to 'uniswap-v3-sdk'. It includes enhancing package information by providing a new description, author details, and inserting the MIT license. Also, the codebase has been updated in various places to reflect this change in identity. GitHub workflow names has been simplified too. The 'cargo clippy' and 'cargo fmt' commands were updated for thorough checking.