### PR TITLE
Add utility to compute maximum liquidity for given amounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,7 +3961,7 @@ dependencies = [
 
 [[package]]
 name = "uniswap-v3-sdk"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap v3 SDK for Rust"

--- a/src/utils/encode_sqrt_ratio_x96.rs
+++ b/src/utils/encode_sqrt_ratio_x96.rs
@@ -1,3 +1,5 @@
+use super::big_int_to_u256;
+use alloy_primitives::U256;
 use num_bigint::BigInt;
 use uniswap_sdk_core::utils::sqrt::sqrt;
 
@@ -8,38 +10,37 @@ use uniswap_sdk_core::utils::sqrt::sqrt;
 /// * `amount1`: The numerator amount i.e., the amount of token1
 /// * `amount0`: The denominator amount i.e., the amount of token0
 ///
-/// returns: BigInt The sqrt ratio
+/// returns: U256 The sqrt ratio as a Q64.96
 ///
-pub fn encode_sqrt_ratio_x96(amount1: impl Into<BigInt>, amount0: impl Into<BigInt>) -> BigInt {
+pub fn encode_sqrt_ratio_x96(amount1: impl Into<BigInt>, amount0: impl Into<BigInt>) -> U256 {
     let numerator: BigInt = amount1.into() << 192;
     let denominator = amount0.into();
-    sqrt(&(numerator / denominator))
+    big_int_to_u256(sqrt(&(numerator / denominator)))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::Q96;
 
     #[test]
     fn test_encode_sqrt_ratio_x96() {
-        let q96 = BigInt::from(1) << 96;
-
-        assert_eq!(encode_sqrt_ratio_x96(1, 1), q96);
+        assert_eq!(encode_sqrt_ratio_x96(1, 1), Q96);
         assert_eq!(
             encode_sqrt_ratio_x96(100, 1),
-            792281625142643375935439503360u128.into()
+            U256::from(792281625142643375935439503360u128)
         );
         assert_eq!(
             encode_sqrt_ratio_x96(1, 100),
-            7922816251426433759354395033u128.into()
+            U256::from(7922816251426433759354395033u128)
         );
         assert_eq!(
             encode_sqrt_ratio_x96(111, 333),
-            45742400955009932534161870629u128.into()
+            U256::from(45742400955009932534161870629u128)
         );
         assert_eq!(
             encode_sqrt_ratio_x96(333, 111),
-            137227202865029797602485611888u128.into()
+            U256::from(137227202865029797602485611888u128)
         );
     }
 }

--- a/src/utils/max_liquidity_for_amounts.rs
+++ b/src/utils/max_liquidity_for_amounts.rs
@@ -1,0 +1,409 @@
+use super::{mul_div, mul_div_96, u256_to_big_uint, Q96};
+use alloy_primitives::U256;
+
+/// Returns an imprecise maximum amount of liquidity received for a given amount of token 0.
+/// This function is available to accommodate LiquidityAmounts#getLiquidityForAmount0 in the v3 periphery,
+/// which could be more precise by at least 32 bits by dividing by Q64 instead of Q96 in the intermediate step,
+/// and shifting the subtracted ratio left by 32 bits. This imprecise calculation will likely be replaced in a future
+/// v3 router contract.
+///
+/// # Arguments
+///
+/// * `sqrt_ratio_a_x96`: The price at the lower boundary
+/// * `sqrt_ratio_b_x96`: The price at the upper boundary
+/// * `amount0`: The token0 amount
+///
+/// returns: liquidity for amount0, imprecise
+///
+pub fn max_liquidity_for_amount0_imprecise(
+    mut sqrt_ratio_a_x96: U256,
+    mut sqrt_ratio_b_x96: U256,
+    amount0: U256,
+) -> U256 {
+    if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
+        (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
+    }
+
+    let intermediate = mul_div_96(sqrt_ratio_a_x96, sqrt_ratio_b_x96).unwrap();
+    mul_div(amount0, intermediate, sqrt_ratio_b_x96 - sqrt_ratio_a_x96).unwrap_or(U256::MAX)
+}
+
+/// Returns a precise maximum amount of liquidity received for a given amount of token 0 by dividing by Q64 instead of
+/// Q96 in the intermediate step, and shifting the subtracted ratio left by 32 bits.
+///
+/// # Arguments
+///
+/// * `sqrt_ratio_a_x96`: The price at the lower boundary
+/// * `sqrt_ratio_b_x96`: The price at the upper boundary
+/// * `amount0`: The token0 amount
+///
+/// returns: liquidity for amount0, precise
+///
+pub fn max_liquidity_for_amount0_precise(
+    mut sqrt_ratio_a_x96: U256,
+    mut sqrt_ratio_b_x96: U256,
+    amount0: U256,
+) -> U256 {
+    if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
+        (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
+    }
+    let sqrt_ratio_a_x96 = u256_to_big_uint(sqrt_ratio_a_x96);
+    let sqrt_ratio_b_x96 = u256_to_big_uint(sqrt_ratio_b_x96);
+    let amount0 = u256_to_big_uint(amount0);
+
+    let numerator = amount0 * sqrt_ratio_a_x96.clone() * sqrt_ratio_b_x96.clone();
+    let denominator = u256_to_big_uint(Q96) * (sqrt_ratio_b_x96 - sqrt_ratio_a_x96);
+
+    let res = numerator / denominator;
+    U256::from_be_slice(&res.to_bytes_be())
+}
+
+/// Computes the maximum amount of liquidity received for a given amount of token1
+///
+/// # Arguments
+///
+/// * `sqrt_ratio_a_x96`: The price at the lower boundary
+/// * `sqrt_ratio_b_x96`: The price at the upper boundary
+/// * `amount1`: The token1 amount
+///
+/// returns: liquidity for amount1
+///
+pub fn max_liquidity_for_amount1(
+    mut sqrt_ratio_a_x96: U256,
+    mut sqrt_ratio_b_x96: U256,
+    amount1: U256,
+) -> U256 {
+    if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
+        (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
+    }
+
+    mul_div(amount1, Q96, sqrt_ratio_b_x96 - sqrt_ratio_a_x96).unwrap_or(U256::MAX)
+}
+
+/// Computes the maximum amount of liquidity received for a given amount of token0, token1,
+/// and the prices at the tick boundaries.
+///
+/// # Arguments
+///
+/// * `sqrt_ratio_current_x96`: The current price
+/// * `sqrt_ratio_a_x96`: The price at the lower boundary
+/// * `sqrt_ratio_b_x96`: The price at the upper boundary
+/// * `amount0`: The token0 amount
+/// * `amount1`: The token1 amount
+/// * `use_full_precision`: if false, liquidity will be maximized according to what the router can calculate,
+/// not what core can theoretically support
+///
+/// returns: maximum liquidity for the given amounts
+///
+pub fn max_liquidity_for_amounts(
+    sqrt_ratio_current_x96: U256,
+    mut sqrt_ratio_a_x96: U256,
+    mut sqrt_ratio_b_x96: U256,
+    amount0: U256,
+    amount1: U256,
+    use_full_precision: bool,
+) -> U256 {
+    if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
+        (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
+    }
+
+    if sqrt_ratio_current_x96 <= sqrt_ratio_a_x96 {
+        if use_full_precision {
+            max_liquidity_for_amount0_precise(sqrt_ratio_a_x96, sqrt_ratio_b_x96, amount0)
+        } else {
+            max_liquidity_for_amount0_imprecise(sqrt_ratio_a_x96, sqrt_ratio_b_x96, amount0)
+        }
+    } else if sqrt_ratio_current_x96 < sqrt_ratio_b_x96 {
+        let liquidity0 = if use_full_precision {
+            max_liquidity_for_amount0_precise(sqrt_ratio_current_x96, sqrt_ratio_b_x96, amount0)
+        } else {
+            max_liquidity_for_amount0_imprecise(sqrt_ratio_current_x96, sqrt_ratio_b_x96, amount0)
+        };
+        let liquidity1 =
+            max_liquidity_for_amount1(sqrt_ratio_a_x96, sqrt_ratio_current_x96, amount1);
+
+        if liquidity0 < liquidity1 {
+            liquidity0
+        } else {
+            liquidity1
+        }
+    } else {
+        max_liquidity_for_amount1(sqrt_ratio_a_x96, sqrt_ratio_b_x96, amount1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::utils::encode_sqrt_ratio_x96;
+
+    #[test]
+    fn imprecise_price_inside_100_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(1, 1),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::from(200),
+                false
+            ),
+            U256::from(2148)
+        );
+    }
+
+    #[test]
+    fn imprecise_price_inside_100_token0_max_token1() {
+        let res = max_liquidity_for_amounts(
+            encode_sqrt_ratio_x96(1, 1),
+            encode_sqrt_ratio_x96(100, 110),
+            encode_sqrt_ratio_x96(110, 100),
+            U256::from(100),
+            U256::MAX,
+            false,
+        );
+        assert_eq!(res, U256::from(2148));
+    }
+
+    #[test]
+    fn imprecise_price_inside_max_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(1, 1),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::MAX,
+                U256::from(200),
+                false
+            ),
+            U256::from(4297)
+        );
+    }
+
+    #[test]
+    fn imprecise_price_below_100_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(99, 110),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::from(200),
+                false
+            ),
+            U256::from(1048)
+        );
+    }
+
+    #[test]
+    fn imprecise_price_below_100_token0_max_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(99, 110),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::MAX,
+                false
+            ),
+            U256::from(1048)
+        );
+    }
+
+    #[test]
+    fn imprecise_price_below_max_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(99, 110),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::MAX,
+                U256::from(200),
+                false
+            ),
+            U256::MAX
+        );
+    }
+
+    #[test]
+    fn imprecise_price_above_100_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(111, 100),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::from(200),
+                false
+            ),
+            U256::from(2097)
+        );
+    }
+
+    #[test]
+    fn imprecise_price_above_100_token0_max_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(111, 100),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::MAX,
+                false
+            ),
+            U256::MAX
+        );
+    }
+
+    #[test]
+    fn imprecise_price_above_max_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(111, 100),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::MAX,
+                U256::from(200),
+                false
+            ),
+            U256::from(2097)
+        );
+    }
+
+    #[test]
+    fn precise_price_inside_100_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(1, 1),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::from(200),
+                true
+            ),
+            U256::from(2148)
+        );
+    }
+
+    #[test]
+    fn precise_price_inside_100_token0_max_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(1, 1),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::MAX,
+                true
+            ),
+            U256::from(2148)
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn precise_price_inside_max_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(1, 1),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::MAX,
+                U256::from(200),
+                true
+            ),
+            U256::from(4297)
+        );
+    }
+
+    #[test]
+    fn precise_price_below_100_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(99, 110),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::from(200),
+                true
+            ),
+            U256::from(1048)
+        );
+    }
+
+    #[test]
+    fn precise_price_below_100_token0_max_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(99, 110),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::MAX,
+                true
+            ),
+            U256::from(1048)
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn precise_price_below_max_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(99, 110),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::MAX,
+                U256::from(200),
+                true
+            ),
+            U256::from(4297)
+        );
+    }
+
+    #[test]
+    fn precise_price_above_100_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(111, 100),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::from(200),
+                true
+            ),
+            U256::from(2097)
+        );
+    }
+
+    #[test]
+    fn precise_price_above_100_token0_max_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(111, 100),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::from(100),
+                U256::MAX,
+                true
+            ),
+            U256::MAX
+        );
+    }
+
+    #[test]
+    fn precise_price_above_max_token0_200_token1() {
+        assert_eq!(
+            max_liquidity_for_amounts(
+                encode_sqrt_ratio_x96(111, 100),
+                encode_sqrt_ratio_x96(100, 110),
+                encode_sqrt_ratio_x96(110, 100),
+                U256::MAX,
+                U256::from(200),
+                true
+            ),
+            U256::from(2097)
+        );
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -5,6 +5,7 @@ mod full_math;
 mod get_fee_growth_inside;
 mod get_tokens_owed;
 mod liquidity_math;
+mod max_liquidity_for_amounts;
 mod nearest_usable_tick;
 mod price_tick_conversions;
 mod sqrt_price_math;
@@ -19,6 +20,7 @@ pub use full_math::*;
 pub use get_fee_growth_inside::*;
 pub use get_tokens_owed::get_tokens_owed;
 pub use liquidity_math::add_delta;
+pub use max_liquidity_for_amounts::*;
 pub use nearest_usable_tick::nearest_usable_tick;
 pub use price_tick_conversions::*;
 pub use sqrt_price_math::*;
@@ -27,7 +29,8 @@ pub use tick_list::TickList;
 pub use tick_math::*;
 
 use alloy_primitives::U256;
-use num_bigint::BigUint;
+use num_bigint::{BigInt, BigUint};
+use num_traits::ToBytes;
 
 pub const Q96: U256 = U256::from_limbs([0, 4294967296, 0, 0]);
 pub const Q128: U256 = U256::from_limbs([0, 0, 1, 0]);
@@ -35,4 +38,12 @@ pub const Q192: U256 = U256::from_limbs([0, 0, 0, 1]);
 
 pub fn u256_to_big_uint(x: U256) -> BigUint {
     BigUint::from_bytes_be(&x.to_be_bytes::<32>())
+}
+
+pub fn big_uint_to_u256(x: BigUint) -> U256 {
+    U256::from_be_slice(&x.to_be_bytes())
+}
+
+pub fn big_int_to_u256(x: BigInt) -> U256 {
+    U256::from_be_slice(&x.to_be_bytes())
 }

--- a/src/utils/price_tick_conversions.rs
+++ b/src/utils/price_tick_conversions.rs
@@ -1,9 +1,7 @@
 use super::{
     encode_sqrt_ratio_x96, get_sqrt_ratio_at_tick, get_tick_at_sqrt_ratio, u256_to_big_uint, Q192,
 };
-use alloy_primitives::U256;
 use anyhow::Result;
-use num_traits::ToBytes;
 use uniswap_sdk_core::prelude::*;
 
 /// Returns a price object corresponding to the input tick and the base/quote token.
@@ -48,7 +46,7 @@ pub fn price_to_closest_tick(price: Price<Token, Token>) -> Result<i32> {
     } else {
         encode_sqrt_ratio_x96(price.denominator().clone(), price.numerator().clone())
     };
-    let tick = get_tick_at_sqrt_ratio(U256::from_le_slice(&sqrt_ratio_x96.to_le_bytes()))?;
+    let tick = get_tick_at_sqrt_ratio(sqrt_ratio_x96)?;
     let next_tick_price = tick_to_price(
         price.meta.base_currency.clone(),
         price.meta.quote_currency.clone(),


### PR DESCRIPTION
This commit adds a new utility to compute the maximum amount of liquidity received for given amounts of two tokens. It provides two variants of computation, one precise and another imprecise, to accommodate both precise and fast computational needs. This utility will help in calculating how much liquidity will be received for given amounts of tokens at certain price boundaries. Tests are also added to verify the functionality of this module.