### PR TITLE
Update data conversions with newly added `types` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitvec"
@@ -583,18 +583,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.17"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80932e03c33999b9235edb8655bc9df3204adc9887c2f95b50cb1deb9fd54253"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.4.17"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c0db58c659eef1c73e444d298c27322a1b52f6927d2ad470c0c0f96fa7b8fa"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -2040,16 +2040,16 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
  "redox_syscall",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "lock_api"
@@ -2476,9 +2476,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "plotters"
@@ -2619,7 +2619,7 @@ checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -3008,7 +3008,7 @@ version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3916,6 +3916,7 @@ dependencies = [
  "bigdecimal",
  "criterion",
  "ethers",
+ "ethers-core",
  "num-bigint",
  "num-integer",
  "num-traits",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "uniswap-v3-sdk"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ aperture-lens = { version = "0.4", optional = true }
 base64 = { version = "0.21.7", optional = true }
 bigdecimal = "0.4.2"
 ethers = { version = "2.0", optional = true }
+ethers-core = "2.0"
 num-bigint = "0.4.4"
 num-integer = "0.1.45"
 num-traits = "0.2.17"

--- a/benches/bit_math.rs
+++ b/benches/bit_math.rs
@@ -1,8 +1,8 @@
 use alloy_primitives::U256;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::ops::Shl;
-use uniswap_v3_math::{bit_math, utils::ruint_to_u256};
-use uniswap_v3_sdk::utils::{least_significant_bit, most_significant_bit};
+use uniswap_v3_math::bit_math;
+use uniswap_v3_sdk::prelude::*;
 
 fn most_significant_bit_benchmark(c: &mut Criterion) {
     c.bench_function("most_significant_bit", |b| {
@@ -18,7 +18,7 @@ fn most_significant_bit_benchmark_ref(c: &mut Criterion) {
     c.bench_function("most_significant_bit_ref", |b| {
         b.iter(|| {
             for i in 1u8..=255 {
-                let _ = bit_math::most_significant_bit(ruint_to_u256(U256::from(1).shl(i)));
+                let _ = bit_math::most_significant_bit(U256::from(1).shl(i).to_ethers());
             }
         })
     });
@@ -38,7 +38,7 @@ fn least_significant_bit_benchmark_ref(c: &mut Criterion) {
     c.bench_function("least_significant_bit_ref", |b| {
         b.iter(|| {
             for i in 1u8..=255 {
-                let _ = bit_math::least_significant_bit(ruint_to_u256(U256::from(1).shl(i)));
+                let _ = bit_math::least_significant_bit(U256::from(1).shl(i).to_ethers());
             }
         });
     });

--- a/benches/sqrt_price_math.rs
+++ b/benches/sqrt_price_math.rs
@@ -1,11 +1,8 @@
 use alloy_primitives::{keccak256, U256};
 use alloy_sol_types::SolValue;
 use criterion::{criterion_group, criterion_main, Criterion};
-use uniswap_v3_math::{sqrt_price_math, utils::ruint_to_u256};
-use uniswap_v3_sdk::utils::{
-    get_amount_0_delta, get_amount_0_delta_signed, get_amount_1_delta, get_amount_1_delta_signed,
-    get_next_sqrt_price_from_input, get_next_sqrt_price_from_output,
-};
+use uniswap_v3_math::sqrt_price_math;
+use uniswap_v3_sdk::prelude::*;
 
 fn pseudo_random(seed: u64) -> U256 {
     keccak256(seed.abi_encode()).into()
@@ -46,9 +43,9 @@ fn get_next_sqrt_price_from_input_benchmark_ref(c: &mut Criterion) {
         b.iter(|| {
             for (sqrt_price_x_96, liquidity, amount, add) in &inputs {
                 let _ = sqrt_price_math::get_next_sqrt_price_from_input(
-                    ruint_to_u256(*sqrt_price_x_96),
+                    sqrt_price_x_96.to_ethers(),
                     *liquidity,
-                    ruint_to_u256(*amount),
+                    amount.to_ethers(),
                     *add,
                 );
             }
@@ -74,9 +71,9 @@ fn get_next_sqrt_price_from_output_benchmark_ref(c: &mut Criterion) {
         b.iter(|| {
             for (sqrt_price_x_96, liquidity, amount, add) in &inputs {
                 let _ = sqrt_price_math::get_next_sqrt_price_from_output(
-                    ruint_to_u256(*sqrt_price_x_96),
+                    sqrt_price_x_96.to_ethers(),
                     *liquidity,
-                    ruint_to_u256(*amount),
+                    amount.to_ethers(),
                     *add,
                 );
             }
@@ -102,8 +99,8 @@ fn get_amount_0_delta_benchmark_ref(c: &mut Criterion) {
         b.iter(|| {
             for (sqrt_ratio_a_x96, liquidity, sqrt_ratio_b_x96, round_up) in &inputs {
                 let _ = sqrt_price_math::_get_amount_0_delta(
-                    ruint_to_u256(*sqrt_ratio_a_x96),
-                    ruint_to_u256(*sqrt_ratio_b_x96),
+                    sqrt_ratio_a_x96.to_ethers(),
+                    sqrt_ratio_b_x96.to_ethers(),
                     *liquidity,
                     *round_up,
                 );
@@ -130,8 +127,8 @@ fn get_amount_1_delta_benchmark_ref(c: &mut Criterion) {
         b.iter(|| {
             for (sqrt_ratio_a_x96, liquidity, sqrt_ratio_b_x96, round_up) in &inputs {
                 let _ = sqrt_price_math::_get_amount_1_delta(
-                    ruint_to_u256(*sqrt_ratio_a_x96),
-                    ruint_to_u256(*sqrt_ratio_b_x96),
+                    sqrt_ratio_a_x96.to_ethers(),
+                    sqrt_ratio_b_x96.to_ethers(),
                     *liquidity,
                     *round_up,
                 );
@@ -161,8 +158,8 @@ fn get_amount_0_delta_signed_benchmark_ref(c: &mut Criterion) {
         b.iter(|| {
             for (sqrt_ratio_a_x96, liquidity, sqrt_ratio_b_x96, _) in &inputs {
                 let _ = sqrt_price_math::get_amount_0_delta(
-                    ruint_to_u256(*sqrt_ratio_a_x96),
-                    ruint_to_u256(*sqrt_ratio_b_x96),
+                    sqrt_ratio_a_x96.to_ethers(),
+                    sqrt_ratio_b_x96.to_ethers(),
                     *liquidity as i128,
                 );
             }
@@ -191,8 +188,8 @@ fn get_amount_1_delta_signed_benchmark_ref(c: &mut Criterion) {
         b.iter(|| {
             for (sqrt_ratio_a_x96, liquidity, sqrt_ratio_b_x96, _) in &inputs {
                 let _ = sqrt_price_math::get_amount_1_delta(
-                    ruint_to_u256(*sqrt_ratio_a_x96),
-                    ruint_to_u256(*sqrt_ratio_b_x96),
+                    sqrt_ratio_a_x96.to_ethers(),
+                    sqrt_ratio_b_x96.to_ethers(),
                     *liquidity as i128,
                 );
             }

--- a/benches/swap_math.rs
+++ b/benches/swap_math.rs
@@ -1,8 +1,8 @@
 use alloy_primitives::{keccak256, I256, U256};
 use alloy_sol_types::SolValue;
 use criterion::{criterion_group, criterion_main, Criterion};
-use uniswap_v3_math::{swap_math, utils::ruint_to_u256};
-use uniswap_v3_sdk::utils::compute_swap_step;
+use uniswap_v3_math::swap_math;
+use uniswap_v3_sdk::prelude::*;
 
 fn pseudo_random(seed: u64) -> U256 {
     keccak256(seed.abi_encode()).into()
@@ -58,10 +58,10 @@ fn compute_swap_step_benchmark_ref(c: &mut Criterion) {
         .into_iter()
         .map(|i| {
             (
-                ruint_to_u256(i.0),
-                ruint_to_u256(i.1),
+                i.0.to_ethers(),
+                i.1.to_ethers(),
                 i.2,
-                I256::from_raw(ruint_to_u256(i.3.into_raw())),
+                I256::from_raw(i.3.into_raw().to_ethers()),
                 i.4,
             )
         })

--- a/benches/tick_math.rs
+++ b/benches/tick_math.rs
@@ -1,8 +1,8 @@
 use alloy_primitives::U256;
 use criterion::{criterion_group, criterion_main, Criterion};
 use std::ops::Shl;
-use uniswap_v3_math::{tick_math, utils::ruint_to_u256};
-use uniswap_v3_sdk::utils::{get_sqrt_ratio_at_tick, get_tick_at_sqrt_ratio};
+use uniswap_v3_math::tick_math;
+use uniswap_v3_sdk::prelude::*;
 
 fn get_sqrt_ratio_at_tick_benchmark(c: &mut Criterion) {
     c.bench_function("get_sqrt_ratio_at_tick", |b| {
@@ -38,7 +38,7 @@ fn get_tick_at_sqrt_ratio_benchmark_ref(c: &mut Criterion) {
     c.bench_function("get_tick_at_sqrt_ratio_ref", |b| {
         b.iter(|| {
             for i in 33u8..=191 {
-                let _ = tick_math::get_tick_at_sqrt_ratio(ruint_to_u256(U256::from(1).shl(i)));
+                let _ = tick_math::get_tick_at_sqrt_ratio(U256::from(1).shl(i).to_ethers());
             }
         });
     });

--- a/src/extensions/ephemeral_tick_data_provider.rs
+++ b/src/extensions/ephemeral_tick_data_provider.rs
@@ -31,7 +31,7 @@ impl EphemeralTickDataProvider {
         let tick_lower = tick_lower.unwrap_or(MIN_TICK);
         let tick_upper = tick_upper.unwrap_or(MAX_TICK);
         let ticks = get_populated_ticks_in_range(
-            pool.into_array().into(),
+            pool.to_ethers(),
             tick_lower,
             tick_upper,
             client.clone(),

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -10,7 +10,6 @@ use ethers::prelude::*;
 use num_integer::Integer;
 use std::sync::Arc;
 use uniswap_sdk_core::{prelude::Token, token};
-use uniswap_v3_math::utils::u256_to_ruint;
 
 pub fn get_pool_contract<M: Middleware>(
     factory: Address,
@@ -90,7 +89,7 @@ pub async fn get_pool<M: Middleware>(
             token_b_name
         ),
         fee,
-        u256_to_ruint(sqrt_price_x96),
+        sqrt_price_x96.to_alloy(),
         liquidity,
         None,
     )
@@ -174,8 +173,7 @@ pub async fn get_liquidity_array_for_pool<M: Middleware>(
     );
     let ticks = get_populated_ticks_in_range(
         pool.address(init_code_hash_manual_override, factory_address_override)
-            .into_array()
-            .into(),
+            .to_ethers(),
         tick_lower,
         tick_upper,
         client,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -12,6 +12,7 @@ mod sqrt_price_math;
 mod swap_math;
 mod tick_list;
 mod tick_math;
+mod types;
 
 pub use bit_math::*;
 pub use compute_pool_address::compute_pool_address;
@@ -27,11 +28,9 @@ pub use sqrt_price_math::*;
 pub use swap_math::compute_swap_step;
 pub use tick_list::TickList;
 pub use tick_math::*;
+pub use types::*;
 
-use alloy_primitives::{uint, I256, U256};
-use num_bigint::{BigInt, BigUint, Sign};
-use num_traits::{Signed, ToBytes};
-use std::ops::Neg;
+use alloy_primitives::{uint, U256};
 
 pub const ONE: U256 = uint!(1_U256);
 pub const TWO: U256 = uint!(2_U256);
@@ -39,39 +38,3 @@ pub const THREE: U256 = uint!(3_U256);
 pub const Q96: U256 = U256::from_limbs([0, 4294967296, 0, 0]);
 pub const Q128: U256 = U256::from_limbs([0, 0, 1, 0]);
 pub const Q192: U256 = U256::from_limbs([0, 0, 0, 1]);
-
-pub fn u256_to_big_uint(x: U256) -> BigUint {
-    BigUint::from_bytes_be(&x.to_be_bytes::<32>())
-}
-
-pub fn u256_to_big_int(x: U256) -> BigInt {
-    BigInt::from_bytes_be(Sign::Plus, &x.to_be_bytes::<32>())
-}
-
-pub fn i256_to_big_int(x: I256) -> BigInt {
-    if x.is_positive() {
-        u256_to_big_int(x.into_raw())
-    } else {
-        u256_to_big_int(x.neg().into_raw()).neg()
-    }
-}
-
-pub fn big_uint_to_u256(x: BigUint) -> U256 {
-    U256::from_be_slice(&x.to_be_bytes())
-}
-
-pub fn big_int_to_u256(x: BigInt) -> U256 {
-    U256::from_be_slice(&x.to_be_bytes())
-}
-
-pub fn big_int_to_i256(x: BigInt) -> I256 {
-    if x.is_positive() {
-        I256::from_raw(big_int_to_u256(x))
-    } else {
-        I256::from_raw(big_int_to_u256(x.neg())).neg()
-    }
-}
-
-pub const fn u128_to_uint256(x: u128) -> U256 {
-    U256::from_limbs([x as u64, (x >> 64) as u64, 0, 0])
-}

--- a/src/utils/sqrt_price_math.rs
+++ b/src/utils/sqrt_price_math.rs
@@ -319,10 +319,7 @@ mod tests {
     use super::*;
     use alloy_primitives::keccak256;
     use alloy_sol_types::SolValue;
-    use uniswap_v3_math::{
-        sqrt_price_math,
-        utils::{ruint_to_u256, u256_to_ruint},
-    };
+    use uniswap_v3_math::sqrt_price_math;
 
     fn pseudo_random(seed: u64) -> U256 {
         keccak256(seed.abi_encode()).into()
@@ -363,12 +360,12 @@ mod tests {
         for (sqrt_price_x_96, liquidity, amount, add) in &inputs {
             let res = get_next_sqrt_price_from_input(*sqrt_price_x_96, *liquidity, *amount, *add);
             let ref_ = sqrt_price_math::get_next_sqrt_price_from_input(
-                ruint_to_u256(*sqrt_price_x_96),
+                sqrt_price_x_96.to_ethers(),
                 *liquidity,
-                ruint_to_u256(*amount),
+                amount.to_ethers(),
                 *add,
             )
-            .map(u256_to_ruint);
+            .map(ToAlloy::to_alloy);
             match_u256(res, ref_);
         }
     }
@@ -379,12 +376,12 @@ mod tests {
         for (sqrt_price_x_96, liquidity, amount, add) in &inputs {
             let res = get_next_sqrt_price_from_output(*sqrt_price_x_96, *liquidity, *amount, *add);
             let ref_ = sqrt_price_math::get_next_sqrt_price_from_output(
-                ruint_to_u256(*sqrt_price_x_96),
+                sqrt_price_x_96.to_ethers(),
                 *liquidity,
-                ruint_to_u256(*amount),
+                amount.to_ethers(),
                 *add,
             )
-            .map(u256_to_ruint);
+            .map(ToAlloy::to_alloy);
             match_u256(res, ref_);
         }
     }
@@ -396,12 +393,12 @@ mod tests {
             let res =
                 get_amount_0_delta(*sqrt_ratio_a_x96, *sqrt_ratio_b_x96, *liquidity, *round_up);
             let ref_ = sqrt_price_math::_get_amount_0_delta(
-                ruint_to_u256(*sqrt_ratio_a_x96),
-                ruint_to_u256(*sqrt_ratio_b_x96),
+                sqrt_ratio_a_x96.to_ethers(),
+                sqrt_ratio_b_x96.to_ethers(),
                 *liquidity,
                 *round_up,
             )
-            .map(u256_to_ruint);
+            .map(ToAlloy::to_alloy);
             match_u256(res, ref_);
         }
     }
@@ -413,12 +410,12 @@ mod tests {
             let res =
                 get_amount_1_delta(*sqrt_ratio_a_x96, *sqrt_ratio_b_x96, *liquidity, *round_up);
             let ref_ = sqrt_price_math::_get_amount_1_delta(
-                ruint_to_u256(*sqrt_ratio_a_x96),
-                ruint_to_u256(*sqrt_ratio_b_x96),
+                sqrt_ratio_a_x96.to_ethers(),
+                sqrt_ratio_b_x96.to_ethers(),
                 *liquidity,
                 *round_up,
             )
-            .map(u256_to_ruint);
+            .map(ToAlloy::to_alloy);
             match_u256(res, ref_);
         }
     }
@@ -431,13 +428,13 @@ mod tests {
                 get_amount_0_delta_signed(*sqrt_ratio_a_x96, *sqrt_ratio_b_x96, *liquidity as i128)
                     .map(I256::into_raw);
             let ref_ = sqrt_price_math::get_amount_0_delta(
-                ruint_to_u256(*sqrt_ratio_a_x96),
-                ruint_to_u256(*sqrt_ratio_b_x96),
+                sqrt_ratio_a_x96.to_ethers(),
+                sqrt_ratio_b_x96.to_ethers(),
                 *liquidity as i128,
             );
             match ref_ {
                 Ok(ref_) => {
-                    assert_eq!(res.unwrap(), u256_to_ruint(ref_.into_raw()));
+                    assert_eq!(res.unwrap(), ref_.into_raw().to_alloy());
                 }
                 Err(e) => {
                     assert_eq!(res.unwrap_err().to_string(), e.to_string());
@@ -454,13 +451,13 @@ mod tests {
                 get_amount_1_delta_signed(*sqrt_ratio_a_x96, *sqrt_ratio_b_x96, *liquidity as i128)
                     .map(I256::into_raw);
             let ref_ = sqrt_price_math::get_amount_1_delta(
-                ruint_to_u256(*sqrt_ratio_a_x96),
-                ruint_to_u256(*sqrt_ratio_b_x96),
+                sqrt_ratio_a_x96.to_ethers(),
+                sqrt_ratio_b_x96.to_ethers(),
                 *liquidity as i128,
             );
             match ref_ {
                 Ok(ref_) => {
-                    assert_eq!(res.unwrap(), u256_to_ruint(ref_.into_raw()));
+                    assert_eq!(res.unwrap(), ref_.into_raw().to_alloy());
                 }
                 Err(e) => {
                     assert_eq!(res.unwrap_err().to_string(), e.to_string());

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -1,0 +1,85 @@
+use alloy_primitives::{Address, I256, U256};
+use ethers_core::types;
+use num_bigint::{BigInt, BigUint, Sign};
+use num_traits::{Signed, ToBytes};
+use std::ops::Neg;
+
+pub trait ToAlloy {
+    type AlloyType;
+
+    fn to_alloy(self) -> Self::AlloyType;
+}
+
+pub trait ToEthers {
+    type EthersType;
+
+    fn to_ethers(self) -> Self::EthersType;
+}
+
+impl ToAlloy for types::U256 {
+    type AlloyType = U256;
+
+    fn to_alloy(self) -> Self::AlloyType {
+        U256::from_limbs(self.0)
+    }
+}
+
+impl ToEthers for U256 {
+    type EthersType = types::U256;
+
+    fn to_ethers(self) -> Self::EthersType {
+        types::U256(self.into_limbs())
+    }
+}
+
+impl ToAlloy for types::Address {
+    type AlloyType = Address;
+
+    fn to_alloy(self) -> Self::AlloyType {
+        self.to_fixed_bytes().into()
+    }
+}
+
+impl ToEthers for Address {
+    type EthersType = types::Address;
+
+    fn to_ethers(self) -> Self::EthersType {
+        self.into_array().into()
+    }
+}
+
+pub fn u256_to_big_uint(x: U256) -> BigUint {
+    BigUint::from_bytes_be(&x.to_be_bytes::<32>())
+}
+
+pub fn u256_to_big_int(x: U256) -> BigInt {
+    BigInt::from_bytes_be(Sign::Plus, &x.to_be_bytes::<32>())
+}
+
+pub fn i256_to_big_int(x: I256) -> BigInt {
+    if x.is_positive() {
+        u256_to_big_int(x.into_raw())
+    } else {
+        u256_to_big_int(x.neg().into_raw()).neg()
+    }
+}
+
+pub fn big_uint_to_u256(x: BigUint) -> U256 {
+    U256::from_be_slice(&x.to_be_bytes())
+}
+
+pub fn big_int_to_u256(x: BigInt) -> U256 {
+    U256::from_be_slice(&x.to_be_bytes())
+}
+
+pub fn big_int_to_i256(x: BigInt) -> I256 {
+    if x.is_positive() {
+        I256::from_raw(big_int_to_u256(x))
+    } else {
+        I256::from_raw(big_int_to_u256(x.neg())).neg()
+    }
+}
+
+pub const fn u128_to_uint256(x: u128) -> U256 {
+    U256::from_limbs([x as u64, (x >> 64) as u64, 0, 0])
+}


### PR DESCRIPTION
This commit introduces a new `types` module which is used to convert between ethers types and alloy types. This provides a more streamlined conversion mechanism and reduces dependencies on individual methods for conversion. This implementation involves changes throughout various parts of the codebase including sqrt price math, bit math, pool, and others. It also includes the addition of ethers-core as a dependency in Cargo.toml.