### PR TITLE
Add multicall functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "uniswap-v3-sdk"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,14 @@
 
 pub mod constants;
 pub mod entities;
+pub mod multicall;
 pub mod utils;
 
 #[cfg(feature = "extensions")]
 pub mod extensions;
 
 pub mod prelude {
-    pub use crate::{constants::*, entities::*, utils::*};
+    pub use crate::{constants::*, entities::*, multicall::encode_multicall, utils::*};
 
     #[cfg(feature = "extensions")]
     pub use crate::extensions::*;

--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -1,0 +1,38 @@
+use alloy_sol_types::{sol, SolCall};
+
+sol! {
+    function multicall(bytes[] data) external payable returns (bytes[] results);
+}
+
+pub fn encode_multicall(data: Vec<Vec<u8>>) -> Vec<u8> {
+    if data.len() == 1 {
+        data[0].clone()
+    } else {
+        let multicall = multicallCall { data };
+        multicall.abi_encode()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::hex;
+
+    #[test]
+    fn test_encode_multicall_string_array_len_1() {
+        let calldata = encode_multicall(vec![vec![0x01]]);
+        assert_eq!(calldata, vec![0x01]);
+    }
+
+    #[test]
+    fn test_encode_multicall_string_array_len_2() {
+        let calldata = encode_multicall(vec![
+            hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").to_vec(),
+            hex!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").to_vec(),
+        ]);
+        assert_eq!(
+            calldata,
+            hex!("ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+        );
+    }
+}


### PR DESCRIPTION
A new module `multicall` has been added to provide multicall functionality within the `uniswap-v3-sdk`. This includes the creation of a new `multicall` solidity function and an `encode_multicall` function for encoding the input data. Associated tests for these functions have been included as well. Also, the package version has been updated from 0.14.0 to 0.15.0.