### PR TITLE
Add `Route` entity and upgrade dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1364,9 +1364,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6267a1fa6f59179ea4afc8e50fd8612a3cc60bc858f786ff877a4a8cb042799"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -1859,9 +1859,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433de089bd45971eecf4668ee0ee8f4cec17db4f8bd8f7bc3197a6ce37aa7d9b"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2027,9 +2027,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -2128,6 +2128,12 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2578,7 +2584,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.21.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -2818,9 +2824,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2844,6 +2850,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-rustls",
@@ -3007,9 +3014,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
  "bitflags 2.4.2",
  "errno",
@@ -3318,7 +3325,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror",
- "time 0.3.31",
+ "time 0.3.33",
 ]
 
 [[package]]
@@ -3490,6 +3497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3573,12 +3586,13 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "00b24b79b7a07f10209f19e683ca1e289d80b1e76ffa8c2b779718566a083679"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
@@ -3593,10 +3607,11 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -3636,9 +3651,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3705,14 +3720,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "c6a4b9e8023eb94392d3dca65d717c53abc5dad49c07cb65bb8fcd87115fa325"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -3748,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap",
  "serde",
@@ -3909,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "uniswap-v3-sdk"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4114,9 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.25.3"
+version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1778a42e8b3b90bff8d0f5032bf22250792889a5cdc752aa0020c84abe3aaf10"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -4283,9 +4298,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.35"
+version = "0.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1931d78a9c73861da0134f453bb1f790ce49b2e30eba8410b4b79bac72b46a2d"
+checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
 dependencies = [
  "memchr",
 ]
@@ -4370,7 +4385,7 @@ dependencies = [
  "hmac",
  "pbkdf2 0.11.0",
  "sha1",
- "time 0.3.31",
+ "time 0.3.33",
  "zstd",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -39,7 +39,7 @@ extensions = ["aperture-lens", "base64", "ethers", "regex", "serde_json"]
 [dev-dependencies]
 criterion = "0.5.1"
 ethers = "2.0"
-tokio = { version = "1.35", features = ["full"] }
+tokio = { version = "1.36", features = ["full"] }
 
 [[bench]]
 name = "bit_math"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ WIP.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "0.11.0", features = ["extensions"] }
+uniswap-v3-sdk = { version = "0.20.0", features = ["extensions"] }
 ```
 
 ### Usage

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -1,11 +1,13 @@
 mod pool;
 mod position;
+mod route;
 mod tick;
 mod tick_data_provider;
 mod tick_list_data_provider;
 
 pub use pool::Pool;
 pub use position::{MintAmounts, Position};
+pub use route::Route;
 pub use tick::{Tick, TickTrait};
 pub use tick_data_provider::*;
 pub use tick_list_data_provider::TickListDataProvider;

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -1,0 +1,354 @@
+use crate::prelude::Pool;
+use alloy_primitives::ChainId;
+use anyhow::Result;
+use uniswap_sdk_core::prelude::*;
+
+/// Represents a list of pools through which a swap can occur
+#[derive(Clone, PartialEq, Debug)]
+pub struct Route<TInput: CurrencyTrait, TOutput: CurrencyTrait, P> {
+    pub pools: Vec<Pool<P>>,
+    pub token_path: Vec<Token>,
+    /// The input token
+    pub input: TInput,
+    /// The output token
+    pub output: TOutput,
+    _mid_price: Option<Price<TInput, TOutput>>,
+}
+
+impl<TInput: CurrencyTrait, TOutput: CurrencyTrait, P> Route<TInput, TOutput, P> {
+    /// Creates an instance of route.
+    ///
+    /// ## Arguments
+    ///
+    /// * `pools`: An array of [`Pool`] objects, ordered by the route the swap will take
+    /// * `input`: The input token
+    /// * `output`: The output token
+    ///
+    pub fn new(pools: Vec<Pool<P>>, input: TInput, output: TOutput) -> Self {
+        assert!(pools.len() > 0, "POOLS");
+
+        let chain_id = pools[0].chain_id();
+        let all_on_same_chain = pools.iter().all(|pool| pool.chain_id() == chain_id);
+        assert!(all_on_same_chain, "CHAIN_IDS");
+
+        let wrapped_input = input.wrapped();
+        assert!(pools[0].involves_token(&wrapped_input), "INPUT");
+
+        assert!(
+            pools.last().unwrap().involves_token(&output.wrapped()),
+            "OUTPUT"
+        );
+
+        let mut token_path: Vec<Token> = vec![wrapped_input];
+        for (i, pool) in pools.iter().enumerate() {
+            let current_input_token = &token_path[i];
+            assert!(
+                current_input_token.equals(&pool.token0)
+                    || current_input_token.equals(&pool.token1),
+                "PATH"
+            );
+            let next_token = if current_input_token.equals(&pool.token0) {
+                pool.token1.clone()
+            } else {
+                pool.token0.clone()
+            };
+            token_path.push(next_token);
+        }
+        assert!(token_path.last().unwrap().equals(&output.wrapped()), "PATH");
+
+        Route {
+            pools,
+            token_path,
+            input,
+            output,
+            _mid_price: None,
+        }
+    }
+
+    pub fn chain_id(&self) -> ChainId {
+        self.pools[0].chain_id()
+    }
+
+    /// Returns the mid price of the route
+    pub fn mid_price(&mut self) -> Result<Price<TInput, TOutput>> {
+        if let Some(mid_price) = &self._mid_price {
+            return Ok(mid_price.clone());
+        }
+        let mut price: Price<Token, Token>;
+        let mut next_input: Token;
+        if self.pools[0].token0.equals(&self.input.wrapped()) {
+            price = self.pools[0].token0_price();
+            next_input = self.pools[0].token1.clone();
+        } else {
+            price = self.pools[0].token1_price();
+            next_input = self.pools[0].token0.clone();
+        }
+        for pool in self.pools[1..].iter_mut() {
+            if next_input.equals(&pool.token0) {
+                next_input = pool.token1.clone();
+                price = price.multiply(&pool.token0_price())?;
+            } else {
+                next_input = pool.token0.clone();
+                price = price.multiply(&pool.token1_price())?;
+            }
+        }
+        self._mid_price = Some(Price::new(
+            self.input.clone(),
+            self.output.clone(),
+            price.denominator(),
+            price.numerator(),
+        ));
+        Ok(self._mid_price.clone().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::prelude::*;
+    use once_cell::sync::Lazy;
+    use uniswap_sdk_core::token;
+
+    static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(1));
+    static TOKEN0: Lazy<Token> =
+        Lazy::new(|| token!(1, "0x0000000000000000000000000000000000000001", 18, "t0"));
+    static TOKEN1: Lazy<Token> =
+        Lazy::new(|| token!(1, "0x0000000000000000000000000000000000000002", 18, "t1"));
+    static TOKEN2: Lazy<Token> =
+        Lazy::new(|| token!(1, "0x0000000000000000000000000000000000000003", 18, "t2"));
+    static WETH: Lazy<Token> = Lazy::new(|| WETH9::new().get(1).unwrap().clone());
+
+    mod path {
+        use super::*;
+
+        static POOL_0_1: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN0.clone(),
+                TOKEN1.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(1, 1),
+                0,
+            )
+            .unwrap()
+        });
+        static POOL_0_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN0.clone(),
+                WETH.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(1, 1),
+                0,
+            )
+            .unwrap()
+        });
+        static POOL_1_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN1.clone(),
+                WETH.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(1, 1),
+                0,
+            )
+            .unwrap()
+        });
+
+        #[test]
+        fn constructs_a_path_from_the_tokens() {
+            let route = Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), TOKEN1.clone());
+            assert_eq!(route.pools, vec![POOL_0_1.clone()]);
+            assert_eq!(route.token_path, vec![TOKEN0.clone(), TOKEN1.clone()]);
+            assert_eq!(route.input, TOKEN0.clone());
+            assert_eq!(route.output, TOKEN1.clone());
+            assert_eq!(route.chain_id(), 1);
+        }
+
+        #[test]
+        #[should_panic]
+        fn fails_if_the_input_is_not_in_the_first_pool() {
+            Route::new(vec![POOL_0_1.clone()], WETH.clone(), TOKEN1.clone());
+        }
+
+        #[test]
+        #[should_panic]
+        fn fails_if_output_is_not_in_the_last_pool() {
+            Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), WETH.clone());
+        }
+
+        #[test]
+        fn can_have_a_token_as_both_input_and_output() {
+            let route = Route::new(
+                vec![POOL_0_WETH.clone(), POOL_0_1.clone(), POOL_1_WETH.clone()],
+                WETH.clone(),
+                WETH.clone(),
+            );
+            assert_eq!(
+                route.pools,
+                vec![POOL_0_WETH.clone(), POOL_0_1.clone(), POOL_1_WETH.clone()]
+            );
+            assert_eq!(route.input, WETH.clone());
+            assert_eq!(route.output, WETH.clone());
+        }
+
+        #[test]
+        fn supports_ether_input() {
+            let route = Route::new(vec![POOL_0_WETH.clone()], ETHER.clone(), TOKEN0.clone());
+            assert_eq!(route.pools, vec![POOL_0_WETH.clone()]);
+            assert_eq!(route.input, ETHER.clone());
+            assert_eq!(route.output, TOKEN0.clone());
+        }
+
+        #[test]
+        fn supports_ether_output() {
+            let route = Route::new(vec![POOL_0_WETH.clone()], TOKEN0.clone(), ETHER.clone());
+            assert_eq!(route.pools, vec![POOL_0_WETH.clone()]);
+            assert_eq!(route.input, TOKEN0.clone());
+            assert_eq!(route.output, ETHER.clone());
+        }
+    }
+
+    mod mid_price {
+        use super::*;
+
+        static POOL_0_1: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN0.clone(),
+                TOKEN1.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(1, 5),
+                0,
+            )
+            .unwrap()
+        });
+        static POOL_1_2: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN1.clone(),
+                TOKEN2.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(15, 30),
+                0,
+            )
+            .unwrap()
+        });
+        static POOL_0_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN0.clone(),
+                WETH.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(3, 1),
+                0,
+            )
+            .unwrap()
+        });
+        static POOL_1_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+            Pool::new(
+                TOKEN1.clone(),
+                WETH.clone(),
+                FeeAmount::MEDIUM,
+                encode_sqrt_ratio_x96(1, 7),
+                0,
+            )
+            .unwrap()
+        });
+
+        #[test]
+        fn correct_for_0_1() {
+            let mut route = Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), TOKEN1.clone());
+            let price = route.mid_price().unwrap();
+            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.2000");
+            assert_eq!(price.meta.base_currency, TOKEN0.clone());
+            assert_eq!(price.meta.quote_currency, TOKEN1.clone());
+        }
+
+        #[test]
+        fn is_cached() {
+            let mut route = Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), TOKEN1.clone());
+            let price = route.mid_price().unwrap();
+            assert_eq!(price, route.mid_price().unwrap());
+        }
+
+        #[test]
+        fn correct_for_1_0() {
+            let mut route = Route::new(vec![POOL_0_1.clone()], TOKEN1.clone(), TOKEN0.clone());
+            let price = route.mid_price().unwrap();
+            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "5.0000");
+            assert_eq!(price.meta.base_currency, TOKEN1.clone());
+            assert_eq!(price.meta.quote_currency, TOKEN0.clone());
+        }
+
+        #[test]
+        fn correct_for_0_1_2() {
+            let mut route = Route::new(
+                vec![POOL_0_1.clone(), POOL_1_2.clone()],
+                TOKEN0.clone(),
+                TOKEN2.clone(),
+            );
+            let price = route.mid_price().unwrap();
+            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.1000");
+            assert_eq!(price.meta.base_currency, TOKEN0.clone());
+            assert_eq!(price.meta.quote_currency, TOKEN2.clone());
+        }
+
+        #[test]
+        fn correct_for_2_1_0() {
+            let mut route = Route::new(
+                vec![POOL_1_2.clone(), POOL_0_1.clone()],
+                TOKEN2.clone(),
+                TOKEN0.clone(),
+            );
+            let price = route.mid_price().unwrap();
+            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "10.0000");
+            assert_eq!(price.meta.base_currency, TOKEN2.clone());
+            assert_eq!(price.meta.quote_currency, TOKEN0.clone());
+        }
+
+        #[test]
+        fn correct_for_ether_0() {
+            let mut route = Route::new(vec![POOL_0_WETH.clone()], ETHER.clone(), TOKEN0.clone());
+            let price = route.mid_price().unwrap();
+            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.3333");
+            assert_eq!(price.meta.base_currency, ETHER.clone());
+            assert_eq!(price.meta.quote_currency, TOKEN0.clone());
+        }
+
+        #[test]
+        fn correct_for_1_weth() {
+            let mut route = Route::new(vec![POOL_1_WETH.clone()], TOKEN1.clone(), WETH.clone());
+            let price = route.mid_price().unwrap();
+            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.1429");
+            assert_eq!(price.meta.base_currency, TOKEN1.clone());
+            assert_eq!(price.meta.quote_currency, WETH.clone());
+        }
+
+        #[test]
+        fn correct_for_ether_0_1_weth() {
+            let mut route = Route::new(
+                vec![POOL_0_WETH.clone(), POOL_0_1.clone(), POOL_1_WETH.clone()],
+                ETHER.clone(),
+                WETH.clone(),
+            );
+            let price = route.mid_price().unwrap();
+            assert_eq!(
+                price.to_significant(4, Rounding::RoundHalfUp).unwrap(),
+                "0.009524"
+            );
+            assert_eq!(price.meta.base_currency, ETHER.clone());
+            assert_eq!(price.meta.quote_currency, WETH.clone());
+        }
+
+        #[test]
+        fn correct_for_weth_0_1_ether() {
+            let mut route = Route::new(
+                vec![POOL_0_WETH.clone(), POOL_0_1.clone(), POOL_1_WETH.clone()],
+                WETH.clone(),
+                ETHER.clone(),
+            );
+            let price = route.mid_price().unwrap();
+            assert_eq!(
+                price.to_significant(4, Rounding::RoundHalfUp).unwrap(),
+                "0.009524"
+            );
+            assert_eq!(price.meta.base_currency, WETH.clone());
+            assert_eq!(price.meta.quote_currency, ETHER.clone());
+        }
+    }
+}

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -25,7 +25,7 @@ impl<TInput: CurrencyTrait, TOutput: CurrencyTrait, P> Route<TInput, TOutput, P>
     /// * `output`: The output token
     ///
     pub fn new(pools: Vec<Pool<P>>, input: TInput, output: TOutput) -> Self {
-        assert!(pools.len() > 0, "POOLS");
+        assert!(!pools.is_empty(), "POOLS");
 
         let chain_id = pools[0].chain_id();
         let all_on_same_chain = pools.iter().all(|pool| pool.chain_id() == chain_id);


### PR DESCRIPTION
This commit adds a new entity called Route which represents a list of pools through which a swap can occur, with associated constructor and methods. Along with this, the code also includes test cases for the new entity. Additionally, the version of the package has also been bumped up along with various dependency upgrades including tokio and toml_edit.