### PR TITLE
Add swap router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2484,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "plotters"
@@ -3780,7 +3780,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.0",
+ "winnow 0.6.1",
 ]
 
 [[package]]
@@ -3934,7 +3934,7 @@ dependencies = [
 
 [[package]]
 name = "uniswap-v3-sdk"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4317,9 +4317,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1dbce9e90e5404c5a52ed82b1d13fc8cfbdad85033b6f57546ffd1265f8451"
+checksum = "d90f4e0f530c4c69f62b80d839e9ef3855edc9cba471a160c4d692deed62b401"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -228,4 +228,52 @@ sol! {
                 uint256 gasEstimate
             );
     }
+
+    interface ISwapRouter {
+        struct ExactInputSingleParams {
+            address tokenIn;
+            address tokenOut;
+            uint24 fee;
+            address recipient;
+            uint256 deadline;
+            uint256 amountIn;
+            uint256 amountOutMinimum;
+            uint160 sqrtPriceLimitX96;
+        }
+
+        function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+        struct ExactInputParams {
+            bytes path;
+            address recipient;
+            uint256 deadline;
+            uint256 amountIn;
+            uint256 amountOutMinimum;
+        }
+
+        function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+
+        struct ExactOutputSingleParams {
+            address tokenIn;
+            address tokenOut;
+            uint24 fee;
+            address recipient;
+            uint256 deadline;
+            uint256 amountOut;
+            uint256 amountInMaximum;
+            uint160 sqrtPriceLimitX96;
+        }
+
+        function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+        struct ExactOutputParams {
+            bytes path;
+            address recipient;
+            uint256 deadline;
+            uint256 amountOut;
+            uint256 amountInMaximum;
+        }
+
+        function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+    }
 }

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -590,16 +590,18 @@ where
     /// ## Arguments
     ///
     /// * `slippage_tolerance`: The tolerance of unfavorable slippage from the execution price of this trade
+    /// * `amount_out`: The amount to receive
     ///
     pub fn minimum_amount_out(
         &mut self,
         slippage_tolerance: Percent,
+        amount_out: Option<CurrencyAmount<TOutput>>,
     ) -> Result<CurrencyAmount<TOutput>> {
         assert!(
             slippage_tolerance >= Percent::new(0, 1),
             "SLIPPAGE_TOLERANCE"
         );
-        let output_amount = self.output_amount()?;
+        let output_amount = amount_out.unwrap_or(self.output_amount()?);
         if self.trade_type == TradeType::ExactOutput {
             return self.output_amount();
         }
@@ -658,7 +660,8 @@ where
             self.output_amount()?.meta.currency.clone(),
             self.maximum_amount_in(slippage_tolerance.clone(), None)?
                 .quotient(),
-            self.minimum_amount_out(slippage_tolerance)?.quotient(),
+            self.minimum_amount_out(slippage_tolerance, None)?
+                .quotient(),
         ))
     }
 }
@@ -1967,14 +1970,18 @@ mod tests {
             #[test]
             #[should_panic(expected = "SLIPPAGE_TOLERANCE")]
             fn throws_if_less_than_0() {
-                let _ = EXACT_IN.clone().minimum_amount_out(Percent::new(-1, 100));
+                let _ = EXACT_IN
+                    .clone()
+                    .minimum_amount_out(Percent::new(-1, 100), None);
             }
 
             #[test]
             fn returns_exact_if_0() {
                 let mut trade = EXACT_IN.clone();
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(0, 10000)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(0, 10000), None)
+                        .unwrap(),
                     trade.output_amount().unwrap()
                 );
             }
@@ -1983,15 +1990,21 @@ mod tests {
             fn returns_exact_if_nonzero() {
                 let mut trade = EXACT_IN.clone();
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(0, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(0, 100), None)
+                        .unwrap(),
                     CurrencyAmount::from_raw_amount(TOKEN2.clone(), 7004).unwrap()
                 );
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(5, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(5, 100), None)
+                        .unwrap(),
                     CurrencyAmount::from_raw_amount(TOKEN2.clone(), 6670).unwrap()
                 );
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(200, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(200, 100), None)
+                        .unwrap(),
                     CurrencyAmount::from_raw_amount(TOKEN2.clone(), 2334).unwrap()
                 );
             }
@@ -2016,14 +2029,18 @@ mod tests {
             #[test]
             #[should_panic(expected = "SLIPPAGE_TOLERANCE")]
             fn throws_if_less_than_0() {
-                let _ = EXACT_OUT.clone().minimum_amount_out(Percent::new(-1, 100));
+                let _ = EXACT_OUT
+                    .clone()
+                    .minimum_amount_out(Percent::new(-1, 100), None);
             }
 
             #[test]
             fn returns_exact_if_0() {
                 let mut trade = EXACT_OUT.clone();
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(0, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(0, 100), None)
+                        .unwrap(),
                     trade.output_amount().unwrap()
                 );
             }
@@ -2032,15 +2049,21 @@ mod tests {
             fn returns_exact_if_nonzero() {
                 let mut trade = EXACT_OUT.clone();
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(0, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(0, 100), None)
+                        .unwrap(),
                     CurrencyAmount::from_raw_amount(TOKEN2.clone(), 100).unwrap()
                 );
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(5, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(5, 100), None)
+                        .unwrap(),
                     CurrencyAmount::from_raw_amount(TOKEN2.clone(), 100).unwrap()
                 );
                 assert_eq!(
-                    trade.minimum_amount_out(Percent::new(200, 100)).unwrap(),
+                    trade
+                        .minimum_amount_out(Percent::new(200, 100), None)
+                        .unwrap(),
                     CurrencyAmount::from_raw_amount(TOKEN2.clone(), 100).unwrap()
                 );
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod payments;
 pub mod quoter;
 pub mod self_permit;
 pub mod staker;
+pub mod swap_router;
 pub mod utils;
 
 #[cfg(feature = "extensions")]
@@ -21,7 +22,7 @@ pub mod prelude {
     pub use crate::{
         abi::*, constants::*, entities::*, multicall::encode_multicall,
         nonfungible_position_manager::*, payments::*, quoter::*, self_permit::*, staker::*,
-        utils::*,
+        swap_router::*, utils::*,
     };
 
     #[cfg(feature = "extensions")]

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -1,0 +1,232 @@
+use crate::prelude::*;
+use alloy_primitives::{Address, U256};
+use alloy_sol_types::SolCall;
+use anyhow::Result;
+use uniswap_sdk_core::{constants::TradeType, prelude::*};
+
+/// Options for producing the arguments to send calls to the router.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SwapOptions {
+    /// How much the execution price is allowed to move unfavorably for the trade execution price.
+    pub slippage_tolerance: Percent,
+    /// The account that should receive the output.
+    pub recipient: Address,
+    /// When the transaction expires, in epoch seconds.
+    pub deadline: U256,
+    /// The optional permit parameters for spending the input.
+    pub input_token_permit: Option<PermitOptions>,
+    /// The optional price limit for the trade.
+    pub sqrt_price_limit_x96: Option<U256>,
+    /// Optional information for taking a fee on output.
+    pub fee: Option<FeeOptions>,
+}
+
+/// Produces the on-chain method name to call and the hex encoded parameters to pass as arguments for a given trade.
+///
+/// ## Arguments
+///
+/// * `trades`: trades to produce call parameters for
+/// * `options`: options for the call parameters
+///
+pub fn swap_call_parameters<TInput: CurrencyTrait, TOutput: CurrencyTrait, P: Clone>(
+    trades: &mut [Trade<TInput, TOutput, P>],
+    options: SwapOptions,
+) -> Result<MethodParameters> {
+    let SwapOptions {
+        slippage_tolerance,
+        recipient,
+        deadline,
+        input_token_permit,
+        sqrt_price_limit_x96,
+        fee,
+    } = options;
+    let mut sample_trade = trades[0].clone();
+    let token_in = sample_trade.input_amount()?.meta.currency.wrapped();
+    let token_out = sample_trade.output_amount()?.meta.currency.wrapped();
+
+    // All trades should have the same starting and ending token.
+    for trade in trades.iter_mut() {
+        assert!(
+            trade
+                .input_amount()?
+                .meta
+                .currency
+                .wrapped()
+                .equals(&token_in),
+            "TOKEN_IN_DIFF"
+        );
+        assert!(
+            trade
+                .output_amount()?
+                .meta
+                .currency
+                .wrapped()
+                .equals(&token_out),
+            "TOKEN_OUT_DIFF"
+        );
+    }
+
+    let mut calldatas: Vec<Vec<u8>> = vec![];
+
+    let mut total_amount_out = BigInt::zero();
+    for trade in trades.iter_mut() {
+        total_amount_out += trade
+            .minimum_amount_out(slippage_tolerance.clone(), None)?
+            .quotient();
+    }
+    let total_amount_out = big_int_to_u256(total_amount_out);
+
+    // flag for whether a refund needs to happen
+    let input_is_native = sample_trade.input_amount()?.meta.currency.is_native();
+    let must_refund = input_is_native && sample_trade.trade_type == TradeType::ExactOutput;
+    // flags for whether funds should be send first to the router
+    let output_is_native = sample_trade.output_amount()?.meta.currency.is_native();
+    let router_must_custody = output_is_native || fee.is_some();
+
+    let mut total_value = BigInt::zero();
+    if input_is_native {
+        for trade in trades.iter_mut() {
+            total_value += trade
+                .maximum_amount_in(slippage_tolerance.clone(), None)?
+                .quotient();
+        }
+    }
+
+    // encode permit if necessary
+    if let Some(input_token_permit) = input_token_permit {
+        assert!(
+            !sample_trade.input_amount()?.meta.currency.is_native(),
+            "NON_TOKEN_PERMIT"
+        );
+        calldatas.push(encode_permit(
+            sample_trade.input_amount()?.meta.currency.wrapped(),
+            input_token_permit,
+        ));
+    }
+
+    for trade in trades.iter_mut() {
+        for Swap {
+            route,
+            input_amount,
+            output_amount,
+        } in trade.swaps.clone().iter_mut()
+        {
+            let amount_in = big_int_to_u256(
+                trade
+                    .maximum_amount_in(slippage_tolerance.clone(), Some(input_amount.clone()))?
+                    .quotient(),
+            );
+            let amount_out = big_int_to_u256(
+                trade
+                    .minimum_amount_out(slippage_tolerance.clone(), Some(output_amount.clone()))?
+                    .quotient(),
+            );
+
+            if route.pools.len() == 1 {
+                calldatas.push(match trade.trade_type {
+                    TradeType::ExactInput => ISwapRouter::exactInputSingleCall {
+                        params: ISwapRouter::ExactInputSingleParams {
+                            tokenIn: route.token_path[0].address(),
+                            tokenOut: route.token_path[1].address(),
+                            fee: route.pools[0].fee as u32,
+                            recipient: if router_must_custody {
+                                Address::ZERO
+                            } else {
+                                recipient
+                            },
+                            deadline,
+                            amountIn: amount_in,
+                            amountOutMinimum: amount_out,
+                            sqrtPriceLimitX96: sqrt_price_limit_x96.unwrap_or_default(),
+                        },
+                    }
+                    .abi_encode(),
+                    TradeType::ExactOutput => ISwapRouter::exactOutputSingleCall {
+                        params: ISwapRouter::ExactOutputSingleParams {
+                            tokenIn: route.token_path[0].address(),
+                            tokenOut: route.token_path[1].address(),
+                            fee: route.pools[0].fee as u32,
+                            recipient: if router_must_custody {
+                                Address::ZERO
+                            } else {
+                                recipient
+                            },
+                            deadline,
+                            amountOut: amount_out,
+                            amountInMaximum: amount_in,
+                            sqrtPriceLimitX96: sqrt_price_limit_x96.unwrap_or_default(),
+                        },
+                    }
+                    .abi_encode(),
+                });
+            } else {
+                assert!(sqrt_price_limit_x96.is_none(), "MULTIHOP_PRICE_LIMIT");
+
+                let path = encode_route_to_path(route, trade.trade_type == TradeType::ExactOutput);
+
+                calldatas.push(match trade.trade_type {
+                    TradeType::ExactInput => ISwapRouter::exactInputCall {
+                        params: ISwapRouter::ExactInputParams {
+                            path,
+                            recipient: if router_must_custody {
+                                Address::ZERO
+                            } else {
+                                recipient
+                            },
+                            deadline,
+                            amountIn: amount_in,
+                            amountOutMinimum: amount_out,
+                        },
+                    }
+                    .abi_encode(),
+                    TradeType::ExactOutput => ISwapRouter::exactOutputCall {
+                        params: ISwapRouter::ExactOutputParams {
+                            path,
+                            recipient: if router_must_custody {
+                                Address::ZERO
+                            } else {
+                                recipient
+                            },
+                            deadline,
+                            amountOut: amount_out,
+                            amountInMaximum: amount_in,
+                        },
+                    }
+                    .abi_encode(),
+                });
+            }
+        }
+    }
+
+    // unwrap
+    if router_must_custody {
+        if let Some(fee) = fee {
+            if output_is_native {
+                calldatas.push(encode_unwrap_weth9(
+                    total_amount_out,
+                    recipient,
+                    Some(fee.clone()),
+                ));
+            } else {
+                calldatas.push(encode_sweep_token(
+                    sample_trade.output_amount()?.meta.currency.address(),
+                    total_amount_out,
+                    recipient,
+                    Some(fee.clone()),
+                ));
+            }
+        } else {
+            calldatas.push(encode_unwrap_weth9(total_amount_out, recipient, None));
+        }
+    }
+
+    // refund
+    if must_refund {
+        calldatas.push(encode_refund_eth());
+    }
+
+    Ok(MethodParameters {
+        calldata: encode_multicall(calldatas),
+        value: big_int_to_u256(total_value),
+    })
+}


### PR DESCRIPTION
This commit introduces the swap router module that provides the functionality to generate call parameters for a trade. It also modifies the `minimum_amount_out` method in `trade.rs` by adding an optional `amount_out` argument. This allows us to either use a given amount or calculate the output amount based on the current trade. The changes to the function is also reflected in all relevant test cases. The package version is updated to 0.23.0.