### PR TITLE
chore(refactor): Refactor code to replace `meta.currency` with `currency`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -30,7 +30,7 @@ regex = { version = "1.10", optional = true }
 ruint = "1.11"
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
-uniswap-sdk-core = "0.15.0"
+uniswap-sdk-core = "0.16.0"
 uniswap_v3_math = "0.4.1"
 
 [features]

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -222,9 +222,9 @@ where
         input_amount: CurrencyAmount<Token>,
         sqrt_price_limit_x96: Option<U256>,
     ) -> Result<(CurrencyAmount<Token>, Self)> {
-        assert!(self.involves_token(&input_amount.meta.currency), "TOKEN");
+        assert!(self.involves_token(&input_amount.currency), "TOKEN");
 
-        let zero_for_one = input_amount.meta.currency.equals(&self.token0);
+        let zero_for_one = input_amount.currency.equals(&self.token0);
 
         let (output_amount, sqrt_ratio_x96, liquidity, _) = self._swap(
             zero_for_one,
@@ -263,9 +263,9 @@ where
         output_amount: CurrencyAmount<Token>,
         sqrt_price_limit_x96: Option<U256>,
     ) -> Result<(CurrencyAmount<Token>, Self)> {
-        assert!(self.involves_token(&output_amount.meta.currency), "TOKEN");
+        assert!(self.involves_token(&output_amount.currency), "TOKEN");
 
-        let zero_for_one = output_amount.meta.currency.equals(&self.token1);
+        let zero_for_one = output_amount.currency.equals(&self.token1);
 
         let (input_amount, sqrt_ratio_x96, liquidity, _) = self._swap(
             zero_for_one,
@@ -696,7 +696,7 @@ mod tests {
         fn get_output_amount_usdc_to_dai() -> Result<()> {
             let (output_amount, _) =
                 POOL.get_output_amount(CurrencyAmount::from_raw_amount(USDC.clone(), 100)?, None)?;
-            assert!(output_amount.meta.currency.equals(&DAI.clone()));
+            assert!(output_amount.currency.equals(&DAI.clone()));
             assert_eq!(output_amount.quotient(), 98.into());
             Ok(())
         }
@@ -705,7 +705,7 @@ mod tests {
         fn get_output_amount_dai_to_usdc() -> Result<()> {
             let (output_amount, _) =
                 POOL.get_output_amount(CurrencyAmount::from_raw_amount(DAI.clone(), 100)?, None)?;
-            assert!(output_amount.meta.currency.equals(&USDC.clone()));
+            assert!(output_amount.currency.equals(&USDC.clone()));
             assert_eq!(output_amount.quotient(), 98.into());
             Ok(())
         }
@@ -714,7 +714,7 @@ mod tests {
         fn get_input_amount_usdc_to_dai() -> Result<()> {
             let (input_amount, _) =
                 POOL.get_input_amount(CurrencyAmount::from_raw_amount(DAI.clone(), 98)?, None)?;
-            assert!(input_amount.meta.currency.equals(&USDC.clone()));
+            assert!(input_amount.currency.equals(&USDC.clone()));
             assert_eq!(input_amount.quotient(), 100.into());
             Ok(())
         }
@@ -723,7 +723,7 @@ mod tests {
         fn get_input_amount_dai_to_usdc() -> Result<()> {
             let (input_amount, _) =
                 POOL.get_input_amount(CurrencyAmount::from_raw_amount(USDC.clone(), 98)?, None)?;
-            assert!(input_amount.meta.currency.equals(&DAI.clone()));
+            assert!(input_amount.currency.equals(&DAI.clone()));
             assert_eq!(input_amount.quotient(), 100.into());
             Ok(())
         }

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -213,8 +213,8 @@ mod tests {
             let mut route = Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), TOKEN1.clone());
             let price = route.mid_price().unwrap();
             assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.2000");
-            assert_eq!(price.meta.base_currency, TOKEN0.clone());
-            assert_eq!(price.meta.quote_currency, TOKEN1.clone());
+            assert_eq!(price.base_currency, TOKEN0.clone());
+            assert_eq!(price.quote_currency, TOKEN1.clone());
         }
 
         #[test]
@@ -229,8 +229,8 @@ mod tests {
             let mut route = Route::new(vec![POOL_0_1.clone()], TOKEN1.clone(), TOKEN0.clone());
             let price = route.mid_price().unwrap();
             assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "5.0000");
-            assert_eq!(price.meta.base_currency, TOKEN1.clone());
-            assert_eq!(price.meta.quote_currency, TOKEN0.clone());
+            assert_eq!(price.base_currency, TOKEN1.clone());
+            assert_eq!(price.quote_currency, TOKEN0.clone());
         }
 
         #[test]
@@ -242,8 +242,8 @@ mod tests {
             );
             let price = route.mid_price().unwrap();
             assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.1000");
-            assert_eq!(price.meta.base_currency, TOKEN0.clone());
-            assert_eq!(price.meta.quote_currency, TOKEN2.clone());
+            assert_eq!(price.base_currency, TOKEN0.clone());
+            assert_eq!(price.quote_currency, TOKEN2.clone());
         }
 
         #[test]
@@ -255,8 +255,8 @@ mod tests {
             );
             let price = route.mid_price().unwrap();
             assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "10.0000");
-            assert_eq!(price.meta.base_currency, TOKEN2.clone());
-            assert_eq!(price.meta.quote_currency, TOKEN0.clone());
+            assert_eq!(price.base_currency, TOKEN2.clone());
+            assert_eq!(price.quote_currency, TOKEN0.clone());
         }
 
         #[test]
@@ -264,8 +264,8 @@ mod tests {
             let mut route = Route::new(vec![POOL_0_WETH.clone()], ETHER.clone(), TOKEN0.clone());
             let price = route.mid_price().unwrap();
             assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.3333");
-            assert_eq!(price.meta.base_currency, ETHER.clone());
-            assert_eq!(price.meta.quote_currency, TOKEN0.clone());
+            assert_eq!(price.base_currency, ETHER.clone());
+            assert_eq!(price.quote_currency, TOKEN0.clone());
         }
 
         #[test]
@@ -273,8 +273,8 @@ mod tests {
             let mut route = Route::new(vec![POOL_1_WETH.clone()], TOKEN1.clone(), WETH.clone());
             let price = route.mid_price().unwrap();
             assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.1429");
-            assert_eq!(price.meta.base_currency, TOKEN1.clone());
-            assert_eq!(price.meta.quote_currency, WETH.clone());
+            assert_eq!(price.base_currency, TOKEN1.clone());
+            assert_eq!(price.quote_currency, WETH.clone());
         }
 
         #[test]
@@ -289,8 +289,8 @@ mod tests {
                 price.to_significant(4, Rounding::RoundHalfUp).unwrap(),
                 "0.009524"
             );
-            assert_eq!(price.meta.base_currency, ETHER.clone());
-            assert_eq!(price.meta.quote_currency, WETH.clone());
+            assert_eq!(price.base_currency, ETHER.clone());
+            assert_eq!(price.quote_currency, WETH.clone());
         }
 
         #[test]
@@ -305,8 +305,8 @@ mod tests {
                 price.to_significant(4, Rounding::RoundHalfUp).unwrap(),
                 "0.009524"
             );
-            assert_eq!(price.meta.base_currency, WETH.clone());
-            assert_eq!(price.meta.quote_currency, ETHER.clone());
+            assert_eq!(price.base_currency, WETH.clone());
+            assert_eq!(price.quote_currency, ETHER.clone());
         }
     }
 }

--- a/src/extensions/price_tick_conversions.rs
+++ b/src/extensions/price_tick_conversions.rs
@@ -116,10 +116,7 @@ pub fn sqrt_ratio_x96_to_price(
 
 /// Same as [`price_to_closest_tick`] but returns [`MIN_TICK`] or [`MAX_TICK`] if the price is outside Uniswap's range.
 pub fn price_to_closest_tick_safe(price: &Price<Token, Token>) -> Result<i32> {
-    let sorted = price
-        .meta
-        .base_currency
-        .sorts_before(&price.meta.quote_currency)?;
+    let sorted = price.base_currency.sorts_before(&price.quote_currency)?;
     if price.as_fraction() < *MIN_PRICE {
         Ok(if sorted { MIN_TICK } else { MAX_TICK })
     } else if price.as_fraction() > *MAX_PRICE {

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -215,8 +215,8 @@ pub fn add_call_parameters<P>(
 fn encode_collect(options: CollectOptions) -> Vec<Vec<u8>> {
     let mut calldatas: Vec<Vec<u8>> = vec![];
 
-    let involves_eth = options.expected_currency_owed0.meta.currency.is_native()
-        || options.expected_currency_owed1.meta.currency.is_native();
+    let involves_eth = options.expected_currency_owed0.currency.is_native()
+        || options.expected_currency_owed1.currency.is_native();
 
     // collect
     calldatas.push(
@@ -239,13 +239,13 @@ fn encode_collect(options: CollectOptions) -> Vec<Vec<u8>> {
         let eth_amount: U256;
         let token: Token;
         let token_amount: U256;
-        if options.expected_currency_owed0.meta.currency.is_native() {
+        if options.expected_currency_owed0.currency.is_native() {
             eth_amount = big_int_to_u256(options.expected_currency_owed0.quotient());
-            token = options.expected_currency_owed1.meta.currency.wrapped();
+            token = options.expected_currency_owed1.currency.wrapped();
             token_amount = big_int_to_u256(options.expected_currency_owed1.quotient());
         } else {
             eth_amount = big_int_to_u256(options.expected_currency_owed1.quotient());
-            token = options.expected_currency_owed0.meta.currency.wrapped();
+            token = options.expected_currency_owed0.currency.wrapped();
             token_amount = big_int_to_u256(options.expected_currency_owed0.quotient());
         }
 
@@ -343,11 +343,11 @@ pub fn remove_call_parameters<P>(
         token_id,
         // add the underlying value to the expected currency already owed
         expected_currency_owed0: expected_currency_owed0.add(&CurrencyAmount::from_raw_amount(
-            expected_currency_owed0.meta.currency.clone(),
+            expected_currency_owed0.currency.clone(),
             u256_to_big_int(amount0_min),
         )?)?,
         expected_currency_owed1: expected_currency_owed1.add(&CurrencyAmount::from_raw_amount(
-            expected_currency_owed1.meta.currency.clone(),
+            expected_currency_owed1.currency.clone(),
             u256_to_big_int(amount1_min),
         )?)?,
         recipient: options.collect_options.recipient,

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -40,27 +40,17 @@ pub fn swap_call_parameters<TInput: CurrencyTrait, TOutput: CurrencyTrait, P: Cl
         fee,
     } = options;
     let mut sample_trade = trades[0].clone();
-    let token_in = sample_trade.input_amount()?.meta.currency.wrapped();
-    let token_out = sample_trade.output_amount()?.meta.currency.wrapped();
+    let token_in = sample_trade.input_amount()?.currency.wrapped();
+    let token_out = sample_trade.output_amount()?.currency.wrapped();
 
     // All trades should have the same starting and ending token.
     for trade in trades.iter_mut() {
         assert!(
-            trade
-                .input_amount()?
-                .meta
-                .currency
-                .wrapped()
-                .equals(&token_in),
+            trade.input_amount()?.currency.wrapped().equals(&token_in),
             "TOKEN_IN_DIFF"
         );
         assert!(
-            trade
-                .output_amount()?
-                .meta
-                .currency
-                .wrapped()
-                .equals(&token_out),
+            trade.output_amount()?.currency.wrapped().equals(&token_out),
             "TOKEN_OUT_DIFF"
         );
     }
@@ -76,10 +66,10 @@ pub fn swap_call_parameters<TInput: CurrencyTrait, TOutput: CurrencyTrait, P: Cl
     let total_amount_out = big_int_to_u256(total_amount_out);
 
     // flag for whether a refund needs to happen
-    let input_is_native = sample_trade.input_amount()?.meta.currency.is_native();
+    let input_is_native = sample_trade.input_amount()?.currency.is_native();
     let must_refund = input_is_native && sample_trade.trade_type == TradeType::ExactOutput;
     // flags for whether funds should be sent first to the router
-    let output_is_native = sample_trade.output_amount()?.meta.currency.is_native();
+    let output_is_native = sample_trade.output_amount()?.currency.is_native();
     let router_must_custody = output_is_native || fee.is_some();
 
     let mut total_value = BigInt::zero();
@@ -94,11 +84,11 @@ pub fn swap_call_parameters<TInput: CurrencyTrait, TOutput: CurrencyTrait, P: Cl
     // encode permit if necessary
     if let Some(input_token_permit) = input_token_permit {
         assert!(
-            !sample_trade.input_amount()?.meta.currency.is_native(),
+            !sample_trade.input_amount()?.currency.is_native(),
             "NON_TOKEN_PERMIT"
         );
         calldatas.push(encode_permit(
-            sample_trade.input_amount()?.meta.currency.wrapped(),
+            sample_trade.input_amount()?.currency.wrapped(),
             input_token_permit,
         ));
     }
@@ -207,7 +197,7 @@ pub fn swap_call_parameters<TInput: CurrencyTrait, TOutput: CurrencyTrait, P: Cl
             ));
         } else {
             calldatas.push(encode_sweep_token(
-                sample_trade.output_amount()?.meta.currency.address(),
+                sample_trade.output_amount()?.currency.address(),
                 total_amount_out,
                 recipient,
                 fee.clone(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -34,9 +34,9 @@ pub use types::*;
 
 use alloy_primitives::{uint, U256};
 
-pub const ONE: U256 = uint!(1_U256);
-pub const TWO: U256 = uint!(2_U256);
-pub const THREE: U256 = uint!(3_U256);
+pub(crate) const ONE: U256 = uint!(1_U256);
+pub(crate) const TWO: U256 = uint!(2_U256);
+pub(crate) const THREE: U256 = uint!(3_U256);
 pub const Q96: U256 = U256::from_limbs([0, 4294967296, 0, 0]);
 pub const Q128: U256 = U256::from_limbs([0, 0, 1, 0]);
 pub const Q192: U256 = U256::from_limbs([0, 0, 0, 1]);

--- a/src/utils/price_tick_conversions.rs
+++ b/src/utils/price_tick_conversions.rs
@@ -35,10 +35,7 @@ pub fn tick_to_price(
 /// * `price`: for which to return the closest tick that represents a price less than or equal to
 /// the input price, i.e. the price of the returned tick is less than or equal to the input price
 pub fn price_to_closest_tick(price: &Price<Token, Token>) -> Result<i32> {
-    let sorted = price
-        .meta
-        .base_currency
-        .sorts_before(&price.meta.quote_currency)?;
+    let sorted = price.base_currency.sorts_before(&price.quote_currency)?;
     let sqrt_ratio_x96 = if sorted {
         encode_sqrt_ratio_x96(price.numerator(), price.denominator())
     } else {
@@ -46,8 +43,8 @@ pub fn price_to_closest_tick(price: &Price<Token, Token>) -> Result<i32> {
     };
     let tick = get_tick_at_sqrt_ratio(sqrt_ratio_x96)?;
     let next_tick_price = tick_to_price(
-        price.meta.base_currency.clone(),
-        price.meta.quote_currency.clone(),
+        price.base_currency.clone(),
+        price.quote_currency.clone(),
         tick + 1,
     )?;
     Ok(if sorted {


### PR DESCRIPTION
This commit refines the uniswap-v3-sdk's source code by replacing occurrences of '.meta.currency' with '.currency'. The change covers several .rs files, from 'swap_router.rs' to 'nonfungible_position_manager.rs', effectively streamlining the code for improved clarity and readability. The 'uniswap-sdk-core' version is also updated from 0.15.0 to 0.16.0.