### PR TITLE
feat(tick): Refactor price tick calculations and implement tick range…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"


### PR DESCRIPTION
… function

The logic in `price_tick_conversions.rs` was refactored to enhance efficiency by using a single instance of `BigDecimal::from(1)`, reducing code redundancy. Added a new function `tick_range_from_width_and_ratio` to determine the tick range based on specified position ratio and range width, providing a more straightforward approach to tick range calculations.