### PR TITLE
refactor(trade): Use `&mut` instead of `RefCell` for best trade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -30,7 +30,7 @@ regex = { version = "1.10", optional = true }
 ruint = "1.12"
 serde_json = { version = "1.0", optional = true }
 thiserror = "1.0"
-uniswap-sdk-core = "0.18"
+uniswap-sdk-core = "0.20.0"
 uniswap_v3_math = "0.4"
 
 [features]


### PR DESCRIPTION
This update refactors the code in trade.rs to directly handle mutable vectors without wrapping them in RefCell. Some iterative operations are also optimized for better readability and performance. Additionally, this update involves an upgrade to the uniswap-sdk-core from version 0.18 to 0.20.0.