### PR TITLE
chore: Refactor tick value clamping and bump package version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.28.0"
+version = "0.29.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -368,11 +368,7 @@ where
                     self.tick_spacing(),
                 )?;
 
-            if step.tick_next < MIN_TICK {
-                step.tick_next = MIN_TICK;
-            } else if step.tick_next > MAX_TICK {
-                step.tick_next = MAX_TICK;
-            }
+            step.tick_next = step.tick_next.clamp(MIN_TICK, MAX_TICK);
 
             step.sqrt_price_next_x96 = get_sqrt_ratio_at_tick(step.tick_next)?;
             (


### PR DESCRIPTION
The tick value clamping in 'src/entities/pool.rs' has been refactored to use the built-in clamp method for more efficient and readable code. Additionally, the package version in 'Cargo.toml' has been updated from 0.28.0 to 0.29.0.