### PR TITLE
refactor: Remove unnecessary `.clone()` calls and update documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -30,7 +30,7 @@ regex = { version = "1.10", optional = true }
 rustc-hash = "2.0"
 serde_json = { version = "1.0", optional = true }
 thiserror = { version = "1.0", optional = true }
-uniswap-sdk-core = { version = "1.0.0-rc", features = ["std"] }
+uniswap-sdk-core = { version = "=1.0.0", features = ["std"] }
 uniswap_v3_math = "0.5.1"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ For easy import, use the prelude:
 use uniswap_v3_sdk::prelude::*;
 ```
 
+## Note on `no_std`
+
+By default, this library does not depend on the standard library (`std`). However, the `std` feature can be enabled to
+use `thiserror` for error handling.
+
 ## Contributing
 
 Contributions are welcome. Please open an issue if you have any questions or suggestions.

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -447,8 +447,7 @@ mod tests {
         #[should_panic(expected = "CHAIN_IDS")]
         fn cannot_be_used_for_tokens_on_different_chains() {
             let weth9 = WETH9::default().get(3).unwrap().clone();
-            Pool::new(USDC.clone(), weth9.clone(), FeeAmount::MEDIUM, ONE_ETHER, 0)
-                .expect("CHAIN_IDS");
+            Pool::new(USDC.clone(), weth9, FeeAmount::MEDIUM, ONE_ETHER, 0).expect("CHAIN_IDS");
         }
 
         #[test]
@@ -461,25 +460,25 @@ mod tests {
         #[test]
         fn works_with_valid_arguments_for_empty_pool_medium_fee() {
             let weth9 = WETH9::default().get(1).unwrap().clone();
-            Pool::new(USDC.clone(), weth9.clone(), FeeAmount::MEDIUM, ONE_ETHER, 0).unwrap();
+            Pool::new(USDC.clone(), weth9, FeeAmount::MEDIUM, ONE_ETHER, 0).unwrap();
         }
 
         #[test]
         fn works_with_valid_arguments_for_empty_pool_low_fee() {
             let weth9 = WETH9::default().get(1).unwrap().clone();
-            Pool::new(USDC.clone(), weth9.clone(), FeeAmount::LOW, ONE_ETHER, 0).unwrap();
+            Pool::new(USDC.clone(), weth9, FeeAmount::LOW, ONE_ETHER, 0).unwrap();
         }
 
         #[test]
         fn works_with_valid_arguments_for_empty_pool_lowest_fee() {
             let weth9 = WETH9::default().get(1).unwrap().clone();
-            Pool::new(USDC.clone(), weth9.clone(), FeeAmount::LOWEST, ONE_ETHER, 0).unwrap();
+            Pool::new(USDC.clone(), weth9, FeeAmount::LOWEST, ONE_ETHER, 0).unwrap();
         }
 
         #[test]
         fn works_with_valid_arguments_for_empty_pool_high_fee() {
             let weth9 = WETH9::default().get(1).unwrap().clone();
-            Pool::new(USDC.clone(), weth9.clone(), FeeAmount::HIGH, ONE_ETHER, 0).unwrap();
+            Pool::new(USDC.clone(), weth9, FeeAmount::HIGH, ONE_ETHER, 0).unwrap();
         }
     }
 

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -143,6 +143,7 @@ fn reconstruct_liquidity_array(
     Ok(liquidity_array)
 }
 
+#[allow(clippy::too_long_first_doc_paragraph)]
 /// Fetches the liquidity within a tick range for the specified pool, using an [ephemeral contract](https://github.com/Aperture-Finance/Aperture-Lens/blob/904101e4daed59e02fd4b758b98b0749e70b583b/contracts/EphemeralGetPopulatedTicksInRange.sol)
 /// in a single `eth_call`.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,11 +30,13 @@
     missing_debug_implementations,
     unreachable_pub,
     clippy::missing_const_for_fn,
+    clippy::redundant_clone,
     rustdoc::all
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+
 extern crate alloc;
 
 pub mod abi;

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -197,17 +197,13 @@ pub fn swap_call_parameters<TInput: Currency, TOutput: Currency, P: Clone>(
     // unwrap
     if router_must_custody {
         if output_is_native {
-            calldatas.push(encode_unwrap_weth9(
-                total_amount_out,
-                recipient,
-                fee.clone(),
-            ));
+            calldatas.push(encode_unwrap_weth9(total_amount_out, recipient, fee));
         } else {
             calldatas.push(encode_sweep_token(
                 sample_trade.output_amount()?.currency.address(),
                 total_amount_out,
                 recipient,
-                fee.clone(),
+                fee,
             ));
         }
     }

--- a/src/utils/max_liquidity_for_amounts.rs
+++ b/src/utils/max_liquidity_for_amounts.rs
@@ -3,6 +3,7 @@ use alloy_primitives::U256;
 use num_bigint::BigUint;
 
 /// Returns an imprecise maximum amount of liquidity received for a given amount of token 0.
+///
 /// This function is available to accommodate LiquidityAmounts#getLiquidityForAmount0 in the v3
 /// periphery, which could be more precise by at least 32 bits by dividing by Q64 instead of Q96 in
 /// the intermediate step, and shifting the subtracted ratio left by 32 bits. This imprecise


### PR DESCRIPTION
Simplify code by removing redundant `.clone()` calls in `swap_router.rs` and `pool.rs`, improving performance. Also, update the README to include a note about the `no_std` feature and bump the crate version to 0.33.0 in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 0.33.0, indicating new enhancements and fixes.
	- Added documentation on compatibility with the Rust `no_std` environment, improving usability for developers in constrained environments.

- **Bug Fixes**
	- Optimized parameter passing in several functions to enhance performance by removing unnecessary cloning.

- **Documentation**
	- Enhanced documentation comments to clarify function purposes and limitations, improving user understanding.

- **Chores**
	- Updated lint warnings to improve code quality and performance checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->