### PR TITLE
refactor: type conversions

### DIFF
--- a/benches/sqrt_price_math.rs
+++ b/benches/sqrt_price_math.rs
@@ -13,21 +13,11 @@ fn pseudo_random_128(seed: u64) -> u128 {
     u128::from_be_bytes(s.to_be_bytes::<32>()[..16].try_into().unwrap())
 }
 
-const fn wrap_to_uint160(x: U256) -> U160 {
-    let limbs = x.into_limbs();
-    U160::from_limbs([limbs[0], limbs[1], limbs[2] % (1 << 32)])
-}
-
-const fn u160_to_u256(x: U160) -> U256 {
-    let limbs = x.into_limbs();
-    U256::from_limbs([limbs[0], limbs[1], limbs[2], 0])
-}
-
 fn generate_inputs() -> Vec<(U160, u128, U256, bool)> {
     (0u64..100)
         .map(|i| {
             (
-                wrap_to_uint160(pseudo_random(i)),
+                U160::saturating_from(pseudo_random(i)),
                 pseudo_random_128(i.pow(2)),
                 pseudo_random(i.pow(3)),
                 i % 2 == 0,
@@ -40,8 +30,8 @@ fn get_amount_inputs() -> Vec<(U160, U160, u128, bool)> {
     (0u64..100)
         .map(|i| {
             (
-                wrap_to_uint160(pseudo_random(i)),
-                wrap_to_uint160(pseudo_random(i.pow(2))),
+                U160::saturating_from(pseudo_random(i)),
+                U160::saturating_from(pseudo_random(i.pow(2))),
                 pseudo_random_128(i.pow(3)),
                 i % 2 == 0,
             )
@@ -52,7 +42,7 @@ fn get_amount_inputs() -> Vec<(U160, U160, u128, bool)> {
 fn get_amount_inputs_ref() -> Vec<(U256, U256, u128, bool)> {
     get_amount_inputs()
         .into_iter()
-        .map(|(a, b, c, d)| (u160_to_u256(a), u160_to_u256(b), c, d))
+        .map(|(a, b, c, d)| (U256::from(a), U256::from(b), c, d))
         .collect::<Vec<_>>()
 }
 
@@ -70,7 +60,7 @@ fn get_next_sqrt_price_from_input_benchmark(c: &mut Criterion) {
 fn get_next_sqrt_price_from_input_benchmark_ref(c: &mut Criterion) {
     let inputs = generate_inputs()
         .into_iter()
-        .map(|(a, b, c, d)| (u160_to_u256(a), b, c, d))
+        .map(|(a, b, c, d)| (U256::from(a), b, c, d))
         .collect::<Vec<_>>();
     c.bench_function("get_next_sqrt_price_from_input_ref", |b| {
         b.iter(|| {
@@ -101,7 +91,7 @@ fn get_next_sqrt_price_from_output_benchmark(c: &mut Criterion) {
 fn get_next_sqrt_price_from_output_benchmark_ref(c: &mut Criterion) {
     let inputs = generate_inputs()
         .into_iter()
-        .map(|(a, b, c, d)| (u160_to_u256(a), b, c, d))
+        .map(|(a, b, c, d)| (U256::from(a), b, c, d))
         .collect::<Vec<_>>();
     c.bench_function("get_next_sqrt_price_from_output_ref", |b| {
         b.iter(|| {

--- a/benches/swap_math.rs
+++ b/benches/swap_math.rs
@@ -15,22 +15,12 @@ fn pseudo_random_128(seed: u64) -> u128 {
     u128::from_be_bytes(s.to_be_bytes::<32>()[..16].try_into().unwrap())
 }
 
-const fn wrap_to_uint160(x: U256) -> U160 {
-    let limbs = x.into_limbs();
-    U160::from_limbs([limbs[0], limbs[1], limbs[2] % (1 << 32)])
-}
-
-const fn u160_to_u256(x: U160) -> U256 {
-    let limbs = x.into_limbs();
-    U256::from_limbs([limbs[0], limbs[1], limbs[2], 0])
-}
-
 fn generate_inputs() -> Vec<(U160, U160, u128, I256, u32)> {
     (0u64..100)
         .map(|i| {
             (
-                wrap_to_uint160(pseudo_random(i)),
-                wrap_to_uint160(pseudo_random(i.pow(2))),
+                U160::saturating_from(pseudo_random(i)),
+                U160::saturating_from(pseudo_random(i.pow(2))),
                 pseudo_random_128(i.pow(3)),
                 I256::from_raw(pseudo_random(i.pow(4))),
                 i as u32,
@@ -68,8 +58,8 @@ fn compute_swap_step_benchmark_ref(c: &mut Criterion) {
         .into_iter()
         .map(|(a, b, c, d, e)| {
             (
-                u160_to_u256(a),
-                u160_to_u256(b),
+                U256::from(a),
+                U256::from(b),
                 c,
                 d.into_raw().try_into().unwrap(),
                 e,

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -5,7 +5,7 @@ use core::{fmt, ops::Neg};
 use once_cell::sync::Lazy;
 use uniswap_sdk_core::prelude::*;
 
-static _Q192: Lazy<BigUint> = Lazy::new(|| u256_to_big_uint(Q192));
+static _Q192: Lazy<BigUint> = Lazy::new(|| Q192.to_big_uint());
 
 /// Represents a V3 pool
 #[derive(Clone)]
@@ -147,7 +147,7 @@ impl<P> Pool<P> {
     /// Returns the current mid price of the pool in terms of token0, i.e. the ratio of token1 over
     /// token0
     pub fn token0_price(&self) -> Price<Token, Token> {
-        let sqrt_ratio_x96: BigUint = u160_to_big_uint(self.sqrt_ratio_x96);
+        let sqrt_ratio_x96 = self.sqrt_ratio_x96.to_big_uint();
         Price::new(
             self.token0.clone(),
             self.token1.clone(),
@@ -159,7 +159,7 @@ impl<P> Pool<P> {
     /// Returns the current mid price of the pool in terms of token1, i.e. the ratio of token0 over
     /// token1
     pub fn token1_price(&self) -> Price<Token, Token> {
-        let sqrt_ratio_x96: BigUint = u160_to_big_uint(self.sqrt_ratio_x96);
+        let sqrt_ratio_x96 = self.sqrt_ratio_x96.to_big_uint();
         Price::new(
             self.token1.clone(),
             self.token0.clone(),
@@ -246,7 +246,7 @@ where
 
         let (output_amount, sqrt_ratio_x96, liquidity, _) = self._swap(
             zero_for_one,
-            big_int_to_i256(input_amount.quotient()),
+            I256::from_big_int(input_amount.quotient()),
             sqrt_price_limit_x96,
         )?;
         let output_token = if zero_for_one {
@@ -255,7 +255,7 @@ where
             self.token0.clone()
         };
         Ok((
-            CurrencyAmount::from_raw_amount(output_token, i256_to_big_int(output_amount.neg()))?,
+            CurrencyAmount::from_raw_amount(output_token, output_amount.neg().to_big_int())?,
             Pool::new_with_tick_data_provider(
                 self.token0.clone(),
                 self.token1.clone(),
@@ -289,7 +289,7 @@ where
 
         let (input_amount, sqrt_ratio_x96, liquidity, _) = self._swap(
             zero_for_one,
-            big_int_to_i256(output_amount.quotient()).neg(),
+            I256::from_big_int(output_amount.quotient()).neg(),
             sqrt_price_limit_x96,
         )?;
         let input_token = if zero_for_one {
@@ -298,7 +298,7 @@ where
             self.token1.clone()
         };
         Ok((
-            CurrencyAmount::from_raw_amount(input_token, i256_to_big_int(input_amount))?,
+            CurrencyAmount::from_raw_amount(input_token, input_amount.to_big_int())?,
             Pool::new_with_tick_data_provider(
                 self.token0.clone(),
                 self.token1.clone(),

--- a/src/entities/position.rs
+++ b/src/entities/position.rs
@@ -99,22 +99,24 @@ impl<P> Position<P> {
             if self.pool.tick_current < self.tick_lower {
                 self._token0_amount = Some(CurrencyAmount::from_raw_amount(
                     self.pool.token0.clone(),
-                    u256_to_big_int(get_amount_0_delta(
+                    get_amount_0_delta(
                         get_sqrt_ratio_at_tick(self.tick_lower)?,
                         get_sqrt_ratio_at_tick(self.tick_upper)?,
                         self.liquidity,
                         false,
-                    )?),
+                    )?
+                    .to_big_int(),
                 )?)
             } else if self.pool.tick_current < self.tick_upper {
                 self._token0_amount = Some(CurrencyAmount::from_raw_amount(
                     self.pool.token0.clone(),
-                    u256_to_big_int(get_amount_0_delta(
+                    get_amount_0_delta(
                         self.pool.sqrt_ratio_x96,
                         get_sqrt_ratio_at_tick(self.tick_upper)?,
                         self.liquidity,
                         false,
-                    )?),
+                    )?
+                    .to_big_int(),
                 )?)
             } else {
                 self._token0_amount = Some(CurrencyAmount::from_raw_amount(
@@ -138,22 +140,24 @@ impl<P> Position<P> {
             } else if self.pool.tick_current < self.tick_upper {
                 self._token1_amount = Some(CurrencyAmount::from_raw_amount(
                     self.pool.token1.clone(),
-                    u256_to_big_int(get_amount_1_delta(
+                    get_amount_1_delta(
                         get_sqrt_ratio_at_tick(self.tick_lower)?,
                         self.pool.sqrt_ratio_x96,
                         self.liquidity,
                         false,
-                    )?),
+                    )?
+                    .to_big_int(),
                 )?)
             } else {
                 self._token1_amount = Some(CurrencyAmount::from_raw_amount(
                     self.pool.token1.clone(),
-                    u256_to_big_int(get_amount_1_delta(
+                    get_amount_1_delta(
                         get_sqrt_ratio_at_tick(self.tick_lower)?,
                         get_sqrt_ratio_at_tick(self.tick_upper)?,
                         self.liquidity,
                         false,
-                    )?),
+                    )?
+                    .to_big_int(),
                 )?)
             }
         }
@@ -185,10 +189,8 @@ impl<P> Position<P> {
         }
 
         let sqrt_ratio_x96_upper = if price_upper
-            >= Fraction::new(
-                u160_to_big_int(MAX_SQRT_RATIO) * u160_to_big_int(MAX_SQRT_RATIO),
-                u256_to_big_int(Q192),
-            ) {
+            >= Fraction::new(MAX_SQRT_RATIO.to_big_int().pow(2), Q192.to_big_int())
+        {
             MAX_SQRT_RATIO - ONE
         } else {
             encode_sqrt_ratio_x96(price_upper.numerator(), price_upper.denominator())
@@ -316,7 +318,7 @@ impl<P> Position<P> {
             .amount1()?
             .quotient();
 
-        Ok((big_int_to_u256(amount0), big_int_to_u256(amount1)))
+        Ok((U256::from_big_int(amount0), U256::from_big_int(amount1)))
     }
 
     /// Returns the minimum amounts that must be sent in order to mint the amount of liquidity held

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -271,8 +271,8 @@ where
         fee_growth_inside_1x128,
     );
     Ok((
-        u128_to_u256(position.tokensOwed0) + tokens_owed_0,
-        u128_to_u256(position.tokensOwed1) + tokens_owed_1,
+        U256::from(position.tokensOwed0) + tokens_owed_0,
+        U256::from(position.tokensOwed1) + tokens_owed_1,
     ))
 }
 
@@ -336,8 +336,8 @@ pub fn get_rebalanced_position<P: Clone>(
         position.pool.clone(),
         new_tick_lower,
         new_tick_upper,
-        big_int_to_u256(amount0_after.to_bigint().unwrap()),
-        big_int_to_u256(amount1_after.to_bigint().unwrap()),
+        U256::from_big_int(amount0_after.to_bigint().unwrap()),
+        U256::from_big_int(amount1_after.to_bigint().unwrap()),
         false,
     )
 }

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -248,13 +248,13 @@ fn encode_collect<Currency0: Currency, Currency1: Currency>(
         let token: Token;
         let token_amount: U256;
         if options.expected_currency_owed0.currency.is_native() {
-            eth_amount = big_int_to_u256(options.expected_currency_owed0.quotient());
+            eth_amount = U256::from_big_int(options.expected_currency_owed0.quotient());
             token = options.expected_currency_owed1.currency.wrapped();
-            token_amount = big_int_to_u256(options.expected_currency_owed1.quotient());
+            token_amount = U256::from_big_int(options.expected_currency_owed1.quotient());
         } else {
-            eth_amount = big_int_to_u256(options.expected_currency_owed1.quotient());
+            eth_amount = U256::from_big_int(options.expected_currency_owed1.quotient());
             token = options.expected_currency_owed0.currency.wrapped();
-            token_amount = big_int_to_u256(options.expected_currency_owed0.quotient());
+            token_amount = U256::from_big_int(options.expected_currency_owed0.quotient());
         }
 
         calldatas.push(encode_unwrap_weth9(eth_amount, options.recipient, None));
@@ -356,11 +356,11 @@ pub fn remove_call_parameters<Currency0: Currency, Currency1: Currency, P>(
         // add the underlying value to the expected currency already owed
         expected_currency_owed0: expected_currency_owed0.add(&CurrencyAmount::from_raw_amount(
             expected_currency_owed0.currency.clone(),
-            u256_to_big_int(amount0_min),
+            amount0_min.to_big_int(),
         )?)?,
         expected_currency_owed1: expected_currency_owed1.add(&CurrencyAmount::from_raw_amount(
             expected_currency_owed1.currency.clone(),
-            u256_to_big_int(amount1_min),
+            amount1_min.to_big_int(),
         )?)?,
         recipient: options.collect_options.recipient,
     }));

--- a/src/payments.rs
+++ b/src/payments.rs
@@ -1,5 +1,4 @@
-use super::abi::IPeripheryPaymentsWithFee;
-use crate::utils::big_int_to_u256;
+use crate::prelude::{FromBig, IPeripheryPaymentsWithFee};
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_sol_types::SolCall;
 use uniswap_sdk_core::prelude::{FractionBase, Percent};
@@ -13,7 +12,7 @@ pub struct FeeOptions {
 }
 
 fn encode_fee_bips(fee: Percent) -> U256 {
-    big_int_to_u256((fee * Percent::new(10000, 1)).quotient())
+    U256::from_big_int((fee * Percent::new(10000, 1)).quotient())
 }
 
 pub fn encode_unwrap_weth9(

--- a/src/quoter.rs
+++ b/src/quoter.rs
@@ -28,7 +28,7 @@ pub fn quote_call_parameters<TInput: Currency, TOutput: Currency, P>(
     options: Option<QuoteOptions>,
 ) -> MethodParameters {
     let options = options.unwrap_or_default();
-    let quote_amount = big_int_to_u256(amount.quotient());
+    let quote_amount = U256::from_big_int(amount.quotient());
 
     let calldata = if route.pools.len() == 1 {
         match trade_type {

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -65,7 +65,7 @@ pub fn swap_call_parameters<TInput: Currency, TOutput: Currency, P: Clone>(
             .minimum_amount_out(slippage_tolerance.clone(), None)?
             .quotient();
     }
-    let total_amount_out = big_int_to_u256(total_amount_out);
+    let total_amount_out = U256::from_big_int(total_amount_out);
 
     // flag for whether a refund needs to happen
     let input_is_native = sample_trade.input_amount()?.currency.is_native();
@@ -102,12 +102,12 @@ pub fn swap_call_parameters<TInput: Currency, TOutput: Currency, P: Clone>(
             output_amount,
         } in trade.swaps.clone().iter_mut()
         {
-            let amount_in = big_int_to_u256(
+            let amount_in = U256::from_big_int(
                 trade
                     .maximum_amount_in(slippage_tolerance.clone(), Some(input_amount.clone()))?
                     .quotient(),
             );
-            let amount_out = big_int_to_u256(
+            let amount_out = U256::from_big_int(
                 trade
                     .minimum_amount_out(slippage_tolerance.clone(), Some(output_amount.clone()))?
                     .quotient(),
@@ -214,7 +214,7 @@ pub fn swap_call_parameters<TInput: Currency, TOutput: Currency, P: Clone>(
 
     Ok(MethodParameters {
         calldata: encode_multicall(calldatas),
-        value: big_int_to_u256(total_value),
+        value: U256::from_big_int(total_value),
     })
 }
 

--- a/src/utils/encode_sqrt_ratio_x96.rs
+++ b/src/utils/encode_sqrt_ratio_x96.rs
@@ -1,4 +1,4 @@
-use super::big_int_to_u160;
+use super::FromBig;
 use alloy_primitives::U160;
 use num_bigint::BigInt;
 use uniswap_sdk_core::utils::sqrt::sqrt;
@@ -14,7 +14,7 @@ use uniswap_sdk_core::utils::sqrt::sqrt;
 pub fn encode_sqrt_ratio_x96(amount1: impl Into<BigInt>, amount0: impl Into<BigInt>) -> U160 {
     let numerator = amount1.into() << 192;
     let denominator = amount0.into();
-    big_int_to_u160(sqrt(&(numerator / denominator)).unwrap())
+    U160::from_big_int(sqrt(&(numerator / denominator)).unwrap())
 }
 
 #[cfg(test)]

--- a/src/utils/get_tokens_owed.rs
+++ b/src/utils/get_tokens_owed.rs
@@ -1,4 +1,4 @@
-use super::{u128_to_u256, Q128};
+use super::Q128;
 use alloy_primitives::U256;
 
 /// Computes the amount of fees owed to a position
@@ -9,7 +9,7 @@ pub fn get_tokens_owed(
     fee_growth_inside_0_x128: U256,
     fee_growth_inside_1_x128: U256,
 ) -> (U256, U256) {
-    let liquidity = u128_to_u256(liquidity);
+    let liquidity = U256::from(liquidity);
     let tokens_owed_0 =
         (fee_growth_inside_0_x128 - fee_growth_inside_0_last_x128) * liquidity / Q128;
     let tokens_owed_1 =

--- a/src/utils/max_liquidity_for_amounts.rs
+++ b/src/utils/max_liquidity_for_amounts.rs
@@ -1,4 +1,4 @@
-use super::{u160_to_big_uint, u256_to_big_uint};
+use super::ToBig;
 use alloy_primitives::{U160, U256};
 use num_bigint::BigUint;
 
@@ -24,11 +24,11 @@ pub fn max_liquidity_for_amount0_imprecise(
     if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
         (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
     }
-    let sqrt_ratio_a_x96 = u160_to_big_uint(sqrt_ratio_a_x96);
-    let sqrt_ratio_b_x96 = u160_to_big_uint(sqrt_ratio_b_x96);
+    let sqrt_ratio_a_x96 = sqrt_ratio_a_x96.to_big_uint();
+    let sqrt_ratio_b_x96 = sqrt_ratio_b_x96.to_big_uint();
 
     let intermediate = (&sqrt_ratio_a_x96 * &sqrt_ratio_b_x96) >> 96;
-    u256_to_big_uint(amount0) * intermediate / (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
+    amount0.to_big_uint() * intermediate / (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
 }
 
 /// Returns a precise maximum amount of liquidity received for a given amount of token 0 by dividing
@@ -50,10 +50,10 @@ pub fn max_liquidity_for_amount0_precise(
     if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
         (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
     }
-    let sqrt_ratio_a_x96 = u160_to_big_uint(sqrt_ratio_a_x96);
-    let sqrt_ratio_b_x96 = u160_to_big_uint(sqrt_ratio_b_x96);
+    let sqrt_ratio_a_x96 = sqrt_ratio_a_x96.to_big_uint();
+    let sqrt_ratio_b_x96 = sqrt_ratio_b_x96.to_big_uint();
 
-    let numerator = u256_to_big_uint(amount0) * &sqrt_ratio_a_x96 * &sqrt_ratio_b_x96;
+    let numerator = amount0.to_big_uint() * &sqrt_ratio_a_x96 * &sqrt_ratio_b_x96;
     let denominator = (sqrt_ratio_b_x96 - sqrt_ratio_a_x96) << 96;
 
     numerator / denominator
@@ -76,10 +76,10 @@ pub fn max_liquidity_for_amount1(
     if sqrt_ratio_a_x96 > sqrt_ratio_b_x96 {
         (sqrt_ratio_a_x96, sqrt_ratio_b_x96) = (sqrt_ratio_b_x96, sqrt_ratio_a_x96);
     }
-    let sqrt_ratio_a_x96 = u160_to_big_uint(sqrt_ratio_a_x96);
-    let sqrt_ratio_b_x96 = u160_to_big_uint(sqrt_ratio_b_x96);
+    let sqrt_ratio_a_x96 = sqrt_ratio_a_x96.to_big_uint();
+    let sqrt_ratio_b_x96 = sqrt_ratio_b_x96.to_big_uint();
 
-    (u256_to_big_uint(amount1) << 96) / (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
+    (amount1.to_big_uint() << 96) / (sqrt_ratio_b_x96 - sqrt_ratio_a_x96)
 }
 
 /// Computes the maximum amount of liquidity received for a given amount of token0, token1,

--- a/src/utils/price_tick_conversions.rs
+++ b/src/utils/price_tick_conversions.rs
@@ -20,8 +20,8 @@ pub fn tick_to_price(
     tick: I24,
 ) -> Result<Price<Token, Token>, Error> {
     let sqrt_ratio_x96 = get_sqrt_ratio_at_tick(tick)?;
-    let ratio_x192 = u160_to_big_uint(sqrt_ratio_x96).pow(2);
-    let q192 = u256_to_big_uint(Q192);
+    let ratio_x192 = sqrt_ratio_x96.to_big_uint().pow(2);
+    let q192 = Q192.to_big_uint();
     Ok(if base_token.sorts_before(&quote_token)? {
         Price::new(base_token, quote_token, q192, ratio_x192)
     } else {

--- a/src/utils/tick_math.rs
+++ b/src/utils/tick_math.rs
@@ -2,7 +2,7 @@
 //! This library is a Rust port of the [TickMath library](https://github.com/uniswap/v3-core/blob/main/contracts/libraries/TickMath.sol) in Solidity,
 //! with custom optimizations presented in [uni-v3-lib](https://github.com/Aperture-Finance/uni-v3-lib/blob/main/src/TickMath.sol).
 
-use super::{most_significant_bit, u160_to_u256, u256_to_u160_unchecked};
+use super::most_significant_bit;
 use crate::error::Error;
 use alloy_primitives::{aliases::I24, uint, U160, U256};
 use core::ops::{Shl, Shr, Sub};
@@ -116,7 +116,7 @@ pub fn get_sqrt_ratio_at_tick(tick: I24) -> Result<U160, Error> {
     }
 
     ratio = (ratio + uint!(0xffffffff_U256)) >> 32;
-    Ok(u256_to_u160_unchecked(ratio))
+    Ok(U160::from(ratio))
 }
 
 /// Returns the tick corresponding to a given sqrt ratio,
@@ -139,7 +139,7 @@ pub fn get_tick_at_sqrt_ratio(sqrt_ratio_x96: U160) -> Result<I24, Error> {
     if (sqrt_ratio_x96 - MIN_SQRT_RATIO) > MAX_SQRT_RATIO_MINUS_MIN_SQRT_RATIO_MINUS_ONE {
         return Err(Error::InvalidSqrtPrice(sqrt_ratio_x96));
     }
-    let sqrt_ratio_x96_u256 = u160_to_u256(sqrt_ratio_x96);
+    let sqrt_ratio_x96_u256 = U256::from(sqrt_ratio_x96);
 
     // Find the most significant bit of `sqrt_ratio_x96`, 160 > msb >= 32.
     let msb = most_significant_bit(sqrt_ratio_x96_u256);


### PR DESCRIPTION
Replaced custom big integer and uint conversion functions with trait implementations for cleaner and more consistent type conversions across modules. This change simplifies the code by introducing `ToBig` and `FromBig` traits for common conversions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced streamlined type conversion methods for `U256` and `U160`, enhancing clarity and performance.
	- Added new traits `ToBig` and `FromBig` for improved conversion capabilities between primitive types and big number representations.

- **Bug Fixes**
	- Improved type safety in conversions, reducing potential runtime errors associated with unchecked conversions.

- **Refactor**
	- Removed redundant conversion functions, replacing them with direct method calls on types.
	- Simplified internal logic across multiple files, enhancing code maintainability.

- **Tests**
	- Added tests to validate the new conversion methods and ensure functionality integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->