### PR TITLE
refactor: pool and tick handling for generic indices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.36.0"
+version = "0.37.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ all-features = true
 alloy = { version = "0.3.1", optional = true, features = ["contract"] }
 alloy-primitives = "0.8"
 alloy-sol-types = "0.8"
-anyhow = "1.0"
+anyhow = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true }
 bigdecimal = "0.4.5"
 num-bigint = "0.4"
@@ -33,7 +33,7 @@ uniswap-sdk-core = "2.1.0"
 
 [features]
 default = []
-extensions = ["uniswap-lens/std", "alloy", "base64", "regex", "serde_json"]
+extensions = ["uniswap-lens/std", "alloy", "anyhow", "base64", "regex", "serde_json"]
 std = ["thiserror", "uniswap-sdk-core/std"]
 
 [dev-dependencies]

--- a/src/entities/mod.rs
+++ b/src/entities/mod.rs
@@ -9,7 +9,7 @@ pub mod trade;
 pub use pool::Pool;
 pub use position::{MintAmounts, Position};
 pub use route::Route;
-pub use tick::{Tick, TickTrait};
+pub use tick::{Tick, TickIndex};
 pub use tick_data_provider::*;
 pub use tick_list_data_provider::TickListDataProvider;
 pub use trade::*;

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -1,11 +1,16 @@
-use crate::prelude::{Error, Pool};
+use crate::prelude::{Error, *};
 use alloy_primitives::ChainId;
 use uniswap_sdk_core::prelude::*;
 
 /// Represents a list of pools through which a swap can occur
 #[derive(Clone, PartialEq, Debug)]
-pub struct Route<TInput: Currency, TOutput: Currency, P> {
-    pub pools: Vec<Pool<P>>,
+pub struct Route<TInput, TOutput, TP>
+where
+    TInput: Currency,
+    TOutput: Currency,
+    TP: TickDataProvider,
+{
+    pub pools: Vec<Pool<TP>>,
     /// The input token
     pub input: TInput,
     /// The output token
@@ -13,7 +18,12 @@ pub struct Route<TInput: Currency, TOutput: Currency, P> {
     _mid_price: Option<Price<TInput, TOutput>>,
 }
 
-impl<TInput: Currency, TOutput: Currency, P> Route<TInput, TOutput, P> {
+impl<TInput, TOutput, TP> Route<TInput, TOutput, TP>
+where
+    TInput: Currency,
+    TOutput: Currency,
+    TP: TickDataProvider,
+{
     /// Creates an instance of route.
     ///
     /// ## Arguments
@@ -22,7 +32,7 @@ impl<TInput: Currency, TOutput: Currency, P> Route<TInput, TOutput, P> {
     /// * `input`: The input token
     /// * `output`: The output token
     #[inline]
-    pub fn new(pools: Vec<Pool<P>>, input: TInput, output: TOutput) -> Self {
+    pub fn new(pools: Vec<Pool<TP>>, input: TInput, output: TOutput) -> Self {
         assert!(!pools.is_empty(), "POOLS");
 
         let chain_id = pools[0].chain_id();
@@ -109,7 +119,7 @@ impl<TInput: Currency, TOutput: Currency, P> Route<TInput, TOutput, P> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{prelude::*, tests::*};
+    use crate::tests::*;
     use once_cell::sync::Lazy;
 
     mod path {
@@ -172,7 +182,7 @@ mod tests {
     mod mid_price {
         use super::*;
 
-        static POOL_0_1: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+        static POOL_0_1: Lazy<Pool> = Lazy::new(|| {
             Pool::new(
                 TOKEN0.clone(),
                 TOKEN1.clone(),
@@ -182,7 +192,7 @@ mod tests {
             )
             .unwrap()
         });
-        static POOL_1_2: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+        static POOL_1_2: Lazy<Pool> = Lazy::new(|| {
             Pool::new(
                 TOKEN1.clone(),
                 TOKEN2.clone(),
@@ -192,7 +202,7 @@ mod tests {
             )
             .unwrap()
         });
-        static POOL_0_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+        static POOL_0_WETH: Lazy<Pool> = Lazy::new(|| {
             Pool::new(
                 TOKEN0.clone(),
                 WETH.clone(),
@@ -202,7 +212,7 @@ mod tests {
             )
             .unwrap()
         });
-        static POOL_1_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+        static POOL_1_WETH: Lazy<Pool> = Lazy::new(|| {
             Pool::new(
                 TOKEN1.clone(),
                 WETH.clone(),

--- a/src/entities/tick.rs
+++ b/src/entities/tick.rs
@@ -1,37 +1,95 @@
-use crate::prelude::{MAX_TICK_I32 as MAX_TICK, MIN_TICK_I32 as MIN_TICK};
+use crate::prelude::*;
+use alloy_primitives::aliases::I24;
+use core::{
+    fmt::Debug,
+    ops::{Add, Div, Mul, Rem, Shl, Shr, Sub},
+};
+use num_integer::Integer;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct Tick {
-    pub index: i32,
+pub struct Tick<I = i32> {
+    pub index: I,
     pub liquidity_gross: u128,
     pub liquidity_net: i128,
 }
 
-pub trait TickTrait: PartialOrd {
-    fn index(&self) -> i32;
+pub trait TickIndex:
+    Copy
+    + Debug
+    + Default
+    + PartialOrd
+    + Add<Output = Self>
+    + Div<Output = Self>
+    + Mul<Output = Self>
+    + Rem<Output = Self>
+    + Sub<Output = Self>
+    + Shl<i32, Output = Self>
+    + Shr<i32, Output = Self>
+    + TryFrom<i32, Error: Debug>
+    + TryInto<i32, Error: Debug>
+{
+    fn zero() -> Self;
 
-    fn liquidity_gross(&self) -> u128;
+    fn one() -> Self;
 
-    fn liquidity_net(&self) -> i128;
+    fn is_zero(self) -> bool {
+        self == Self::zero()
+    }
+
+    fn from_i24(value: I24) -> Self;
+
+    fn to_i24(self) -> I24;
+
+    fn max(self, other: Self) -> Self {
+        if self > other {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn min(self, other: Self) -> Self {
+        if self < other {
+            self
+        } else {
+            other
+        }
+    }
+
+    fn div_floor(self, other: Self) -> Self;
 }
 
-impl TickTrait for Tick {
-    fn index(&self) -> i32 {
-        self.index
+impl TickIndex for i32 {
+    #[inline]
+    fn zero() -> Self {
+        0
     }
 
-    fn liquidity_gross(&self) -> u128 {
-        self.liquidity_gross
+    #[inline]
+    fn one() -> Self {
+        1
     }
 
-    fn liquidity_net(&self) -> i128 {
-        self.liquidity_net
+    fn from_i24(value: I24) -> Self {
+        value.as_i32()
+    }
+
+    fn to_i24(self) -> I24 {
+        I24::try_from(self).unwrap()
+    }
+
+    #[inline]
+    fn div_floor(self, other: Self) -> Self {
+        Integer::div_floor(&self, &other)
     }
 }
 
-impl Tick {
-    pub const fn new(index: i32, liquidity_gross: u128, liquidity_net: i128) -> Self {
-        assert!(index >= MIN_TICK && index <= MAX_TICK, "TICK");
+impl<I: TickIndex> Tick<I> {
+    pub fn new(index: I, liquidity_gross: u128, liquidity_net: i128) -> Self {
+        assert!(
+            index >= I::from_i24(MIN_TICK) && index <= I::from_i24(MAX_TICK),
+            "TICK"
+        );
         Self {
             index,
             liquidity_gross,
@@ -46,13 +104,13 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "TICK")]
-    const fn test_tick_below_min_tick() {
-        Tick::new(MIN_TICK - 1, 0, 0);
+    fn test_tick_below_min_tick() {
+        Tick::new(MIN_TICK_I32 - 1, 0, 0);
     }
 
     #[test]
     #[should_panic(expected = "TICK")]
-    const fn test_tick_above_max_tick() {
-        Tick::new(MAX_TICK + 1, 0, 0);
+    fn test_tick_above_max_tick() {
+        Tick::new(MAX_TICK_I32 + 1, 0, 0);
     }
 }

--- a/src/entities/tick_data_provider.rs
+++ b/src/entities/tick_data_provider.rs
@@ -2,7 +2,7 @@ use crate::prelude::*;
 
 /// Provides information about ticks
 pub trait TickDataProvider: Clone {
-    type Tick;
+    type Index: TickIndex;
 
     /// Return information corresponding to a specific tick
     ///
@@ -10,8 +10,8 @@ pub trait TickDataProvider: Clone {
     ///
     /// * `tick`: The tick to load
     ///
-    /// returns: Result<&Self::Tick, Error>
-    fn get_tick(&self, tick: i32) -> Result<&Self::Tick, Error>;
+    /// returns: Result<&Tick<Self::Index>, Error>
+    fn get_tick(&self, tick: Self::Index) -> Result<&Tick<Self::Index>, Error>;
 
     /// Return the next tick that is initialized within a single word
     ///
@@ -21,13 +21,13 @@ pub trait TickDataProvider: Clone {
     /// * `lte`: Whether the next tick should be lte the current tick
     /// * `tick_spacing`: The tick spacing of the pool
     ///
-    /// returns: Result<(i32, bool), Error>
+    /// returns: Result<(Self::Index, bool), Error>
     fn next_initialized_tick_within_one_word(
         &self,
-        tick: i32,
+        tick: Self::Index,
         lte: bool,
-        tick_spacing: i32,
-    ) -> Result<(i32, bool), Error>;
+        tick_spacing: Self::Index,
+    ) -> Result<(Self::Index, bool), Error>;
 }
 
 /// This tick data provider does not know how to fetch any tick data. It throws whenever it is
@@ -36,7 +36,7 @@ pub trait TickDataProvider: Clone {
 pub struct NoTickDataProvider;
 
 impl TickDataProvider for NoTickDataProvider {
-    type Tick = Tick;
+    type Index = i32;
 
     fn get_tick(&self, _: i32) -> Result<&Tick, Error> {
         Err(Error::NoTickDataError)

--- a/src/entities/tick_list_data_provider.rs
+++ b/src/entities/tick_list_data_provider.rs
@@ -2,28 +2,28 @@ use crate::prelude::*;
 
 /// A data provider for ticks that is backed by an in-memory array of ticks.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct TickListDataProvider(Vec<Tick>);
+pub struct TickListDataProvider<I = i32>(Vec<Tick<I>>);
 
-impl TickListDataProvider {
-    pub fn new(ticks: Vec<Tick>, tick_spacing: i32) -> Self {
+impl<I: TickIndex> TickListDataProvider<I> {
+    pub fn new(ticks: Vec<Tick<I>>, tick_spacing: I) -> Self {
         ticks.validate_list(tick_spacing);
         Self(ticks)
     }
 }
 
-impl TickDataProvider for TickListDataProvider {
-    type Tick = Tick;
+impl<I: TickIndex> TickDataProvider for TickListDataProvider<I> {
+    type Index = I;
 
-    fn get_tick(&self, tick: i32) -> Result<&Tick, Error> {
+    fn get_tick(&self, tick: I) -> Result<&Tick<I>, Error> {
         Ok(self.0.get_tick(tick))
     }
 
     fn next_initialized_tick_within_one_word(
         &self,
-        tick: i32,
+        tick: I,
         lte: bool,
-        tick_spacing: i32,
-    ) -> Result<(i32, bool), Error> {
+        tick_spacing: I,
+    ) -> Result<(I, bool), Error> {
         Ok(self
             .0
             .next_initialized_tick_within_one_word(tick, lte, tick_spacing))
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn can_take_an_empty_list_of_ticks() {
-        TickListDataProvider::default();
+        TickListDataProvider::<i32>::default();
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use alloy::contract::Error as ContractError;
 use alloy_primitives::{aliases::I24, U160};
 use uniswap_sdk_core::error::Error as CoreError;
 
-#[allow(missing_copy_implementations)]
 #[cfg_attr(
     not(feature = "extensions"),
     derive(Clone, Copy, Debug, Hash, PartialEq, Eq)

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -54,7 +54,7 @@ pub async fn get_pool<T, P>(
     fee: FeeAmount,
     provider: P,
     block_id: Option<BlockId>,
-) -> Result<Pool<NoTickDataProvider>, Error>
+) -> Result<Pool, Error>
 where
     T: Transport + Clone,
     P: Provider<T> + Clone,
@@ -202,7 +202,7 @@ mod tests {
     use crate::tests::PROVIDER;
     use alloy_primitives::address;
 
-    async fn pool() -> Pool<NoTickDataProvider> {
+    async fn pool() -> Pool {
         get_pool(
             1,
             FACTORY_ADDRESS,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //!     - [`ephemeral_tick_data_provider`](./src/extensions/ephemeral_tick_data_provider.rs) module for fetching ticks using
 //!       an [ephemeral contract](https://github.com/Aperture-Finance/Aperture-Lens/blob/904101e4daed59e02fd4b758b98b0749e70b583b/contracts/EphemeralGetPopulatedTicksInRange.sol)
 //!       in a single `eth_call`.
+
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![warn(
     missing_copy_implementations,
@@ -36,7 +37,6 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
-#![allow(unused_crate_dependencies)]
 
 extern crate alloc;
 

--- a/src/quoter.rs
+++ b/src/quoter.rs
@@ -21,12 +21,17 @@ pub struct QuoteOptions {
 /// * `amount`: The amount of the quote, either an amount in, or an amount out
 /// * `trade_type`: The trade type, either exact input or exact output
 /// * `options`: The optional params including price limit and Quoter contract switch
-pub fn quote_call_parameters<TInput: Currency, TOutput: Currency, P>(
-    route: &Route<TInput, TOutput, P>,
+pub fn quote_call_parameters<TInput, TOutput, TP>(
+    route: &Route<TInput, TOutput, TP>,
     amount: CurrencyAmount<impl Currency>,
     trade_type: TradeType,
     options: Option<QuoteOptions>,
-) -> MethodParameters {
+) -> MethodParameters
+where
+    TInput: Currency,
+    TOutput: Currency,
+    TP: TickDataProvider,
+{
     let options = options.unwrap_or_default();
     let quote_amount = U256::from_big_int(amount.quotient());
 

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -27,10 +27,15 @@ pub struct SwapOptions {
 ///
 /// * `trades`: trades to produce call parameters for
 /// * `options`: options for the call parameters
-pub fn swap_call_parameters<TInput: Currency, TOutput: Currency, P: Clone>(
-    trades: &mut [Trade<TInput, TOutput, P>],
+pub fn swap_call_parameters<TInput, TOutput, TP>(
+    trades: &mut [Trade<TInput, TOutput, TP>],
     options: SwapOptions,
-) -> Result<MethodParameters, Error> {
+) -> Result<MethodParameters, Error>
+where
+    TInput: Currency,
+    TOutput: Currency,
+    TP: TickDataProvider,
+{
     let SwapOptions {
         slippage_tolerance,
         recipient,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -66,7 +66,7 @@ pub(crate) const FEE_AMOUNT: FeeAmount = FeeAmount::MEDIUM;
 pub(crate) const SQRT_RATIO_X96: U160 = U160::from_limbs([0, 4294967296, 0]);
 pub(crate) const LIQUIDITY: u128 = 1_000_000;
 
-pub(crate) static POOL_0_1: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+pub(crate) static POOL_0_1: Lazy<Pool> = Lazy::new(|| {
     Pool::new(
         TOKEN0.clone(),
         TOKEN1.clone(),
@@ -76,7 +76,7 @@ pub(crate) static POOL_0_1: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
     )
     .unwrap()
 });
-pub(crate) static POOL_0_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+pub(crate) static POOL_0_WETH: Lazy<Pool> = Lazy::new(|| {
     Pool::new(
         TOKEN0.clone(),
         WETH.clone(),
@@ -86,7 +86,7 @@ pub(crate) static POOL_0_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
     )
     .unwrap()
 });
-pub(crate) static POOL_1_WETH: Lazy<Pool<NoTickDataProvider>> = Lazy::new(|| {
+pub(crate) static POOL_1_WETH: Lazy<Pool> = Lazy::new(|| {
     Pool::new(
         TOKEN1.clone(),
         WETH.clone(),

--- a/src/utils/nearest_usable_tick.rs
+++ b/src/utils/nearest_usable_tick.rs
@@ -12,6 +12,7 @@ use num_integer::Integer;
 /// ## Returns
 ///
 /// The closest tick to the input tick that is usable for the given tick spacing
+// TODO: use [`TickIndex`]
 pub fn nearest_usable_tick(tick: I24, tick_spacing: I24) -> I24 {
     let tick = tick.as_i32();
     let tick_spacing = tick_spacing.as_i32();

--- a/src/utils/swap_math.rs
+++ b/src/utils/swap_math.rs
@@ -134,8 +134,31 @@ pub fn compute_swap_step<const BITS: usize, const LIMBS: usize>(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use alloy_primitives::U160;
+
     #[test]
-    const fn test_compute_swap_step() {
-        // TODO: Add more tests
+    fn test_compute_swap_step() {
+        let amount_specified_remaining = I256::from_raw(U256::from_limbs([
+            18446744073709540431,
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+        ]));
+        let (sqrt_price_next_x96, amount_in, amount_out, fee_amount) = compute_swap_step(
+            U160::from_limbs([7164297123421688246, 4074563739, 0]),
+            U160::from_limbs([7829751401545787782, 4282102344, 0]),
+            94868,
+            amount_specified_remaining,
+            FeeAmount::MEDIUM as u32,
+        )
+        .unwrap();
+        assert_eq!(
+            sqrt_price_next_x96,
+            U160::from_limbs([7829751401545787782, 4282102344, 0])
+        );
+        assert_eq!(amount_in, U256::from_limbs([4585, 0, 0, 0]));
+        assert_eq!(amount_out, U256::from_limbs([4846, 0, 0, 0]));
+        assert_eq!(fee_amount, U256::from_limbs([14, 0, 0, 0]));
     }
 }

--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -1,17 +1,16 @@
-use crate::entities::TickTrait;
-use num_integer::Integer;
+use crate::prelude::*;
 
 /// Utility methods for interacting with sorted lists of ticks
 pub trait TickList {
-    type Tick;
+    type Index: TickIndex;
 
-    fn validate_list(&self, tick_spacing: i32);
+    fn validate_list(&self, tick_spacing: Self::Index);
 
-    fn is_below_smallest(&self, tick: i32) -> bool;
+    fn is_below_smallest(&self, tick: Self::Index) -> bool;
 
-    fn is_at_or_above_largest(&self, tick: i32) -> bool;
+    fn is_at_or_above_largest(&self, tick: Self::Index) -> bool;
 
-    fn get_tick(&self, index: i32) -> &Self::Tick;
+    fn get_tick(&self, index: Self::Index) -> &Tick<Self::Index>;
 
     /// Finds the largest tick in the list of ticks that is less than or equal to tick
     ///
@@ -20,25 +19,25 @@ pub trait TickList {
     /// * `tick`: tick to find the largest tick that is less than or equal to tick
     ///
     /// returns: usize
-    fn binary_search_by_tick(&self, tick: i32) -> usize;
+    fn binary_search_by_tick(&self, tick: Self::Index) -> usize;
 
-    fn next_initialized_tick(&self, tick: i32, lte: bool) -> &Self::Tick;
+    fn next_initialized_tick(&self, tick: Self::Index, lte: bool) -> &Tick<Self::Index>;
 
     fn next_initialized_tick_within_one_word(
         &self,
-        tick: i32,
+        tick: Self::Index,
         lte: bool,
-        tick_spacing: i32,
-    ) -> (i32, bool);
+        tick_spacing: Self::Index,
+    ) -> (Self::Index, bool);
 }
 
-impl<T: TickTrait> TickList for [T] {
-    type Tick = T;
+impl<I: TickIndex> TickList for [Tick<I>] {
+    type Index = I;
 
-    fn validate_list(&self, tick_spacing: i32) {
-        assert!(tick_spacing > 0, "TICK_SPACING_NONZERO");
+    fn validate_list(&self, tick_spacing: I) {
+        assert!(tick_spacing > I::zero(), "TICK_SPACING_NONZERO");
         assert!(
-            self.iter().all(|x| x.index() % tick_spacing == 0),
+            self.iter().all(|x| x.index % tick_spacing == I::zero()),
             "TICK_SPACING"
         );
         for i in 1..self.len() {
@@ -47,40 +46,40 @@ impl<T: TickTrait> TickList for [T] {
             }
         }
         assert_eq!(
-            self.iter().fold(0, |acc, x| acc + x.liquidity_net()),
+            self.iter().fold(0, |acc, x| acc + x.liquidity_net),
             0,
             "ZERO_NET"
         );
     }
 
-    fn is_below_smallest(&self, tick: i32) -> bool {
+    fn is_below_smallest(&self, tick: I) -> bool {
         assert!(!self.is_empty(), "LENGTH");
-        tick < self[0].index()
+        tick < self[0].index
     }
 
-    fn is_at_or_above_largest(&self, tick: i32) -> bool {
+    fn is_at_or_above_largest(&self, tick: I) -> bool {
         assert!(!self.is_empty(), "LENGTH");
-        tick >= self.last().unwrap().index()
+        tick >= self.last().unwrap().index
     }
 
-    fn get_tick(&self, index: i32) -> &T {
+    fn get_tick(&self, index: I) -> &Tick<I> {
         let i = Self::binary_search_by_tick(self, index);
         let tick = &self[i];
-        assert_eq!(tick.index(), index, "NOT_CONTAINED");
+        assert_eq!(tick.index, index, "NOT_CONTAINED");
         tick
     }
 
-    fn binary_search_by_tick(&self, tick: i32) -> usize {
+    fn binary_search_by_tick(&self, tick: I) -> usize {
         assert!(!Self::is_below_smallest(self, tick), "BELOW_SMALLEST");
         let mut l = 0;
         let mut r = self.len() - 1;
 
         loop {
             let i = (l + r) / 2;
-            if self[i].index() <= tick && (i == self.len() - 1 || self[i + 1].index() > tick) {
+            if self[i].index <= tick && (i == self.len() - 1 || self[i + 1].index > tick) {
                 return i;
             }
-            if self[i].index() < tick {
+            if self[i].index < tick {
                 l = i + 1;
             } else {
                 r = i - 1;
@@ -88,7 +87,7 @@ impl<T: TickTrait> TickList for [T] {
         }
     }
 
-    fn next_initialized_tick(&self, tick: i32, lte: bool) -> &T {
+    fn next_initialized_tick(&self, tick: I, lte: bool) -> &Tick<I> {
         if lte {
             assert!(!Self::is_below_smallest(self, tick), "BELOW_SMALLEST");
             if Self::is_at_or_above_largest(self, tick) {
@@ -111,11 +110,11 @@ impl<T: TickTrait> TickList for [T] {
 
     fn next_initialized_tick_within_one_word(
         &self,
-        tick: i32,
+        tick: I,
         lte: bool,
-        tick_spacing: i32,
-    ) -> (i32, bool) {
-        let (compressed, _) = tick.div_mod_floor(&tick_spacing);
+        tick_spacing: I,
+    ) -> (I, bool) {
+        let compressed = tick.div_floor(tick_spacing);
         if lte {
             let word_pos = compressed >> 8;
             let minimum = (word_pos << 8) * tick_spacing;
@@ -123,16 +122,17 @@ impl<T: TickTrait> TickList for [T] {
             if Self::is_below_smallest(self, tick) {
                 return (minimum, false);
             }
-            let index = Self::next_initialized_tick(self, tick, lte).index();
+            let index = Self::next_initialized_tick(self, tick, lte).index;
             let next_initialized_tick = minimum.max(index);
             (next_initialized_tick, next_initialized_tick == index)
         } else {
-            let word_pos = (compressed + 1) >> 8;
-            let maximum = ((word_pos << 8) + 255) * tick_spacing;
+            let one = I::one();
+            let word_pos = (compressed + one) >> 8;
+            let maximum = (((word_pos + one) << 8) - one) * tick_spacing;
             if Self::is_at_or_above_largest(self, tick) {
                 return (maximum, false);
             }
-            let index = Self::next_initialized_tick(self, tick, lte).index();
+            let index = Self::next_initialized_tick(self, tick, lte).index;
             let next_initialized_tick = maximum.min(index);
             (next_initialized_tick, next_initialized_tick == index)
         }
@@ -146,37 +146,37 @@ mod tests {
         entities::Tick,
         utils::{MAX_TICK_I32 as MAX_TICK, MIN_TICK_I32 as MIN_TICK},
     };
+    use once_cell::sync::Lazy;
 
-    const LOW_TICK: Tick = Tick::new(MIN_TICK + 1, 10, 10);
-    const MID_TICK: Tick = Tick::new(0, 5, -5);
-    const HIGH_TICK: Tick = Tick::new(MAX_TICK - 1, 5, -5);
-    const TICKS: [Tick; 3] = [LOW_TICK, MID_TICK, HIGH_TICK];
+    static LOW_TICK: Lazy<Tick> = Lazy::new(|| Tick::new(MIN_TICK + 1, 10, 10));
+    static MID_TICK: Lazy<Tick> = Lazy::new(|| Tick::new(0, 5, -5));
+    static HIGH_TICK: Lazy<Tick> = Lazy::new(|| Tick::new(MAX_TICK - 1, 5, -5));
+    static TICKS: Lazy<[Tick; 3]> = Lazy::new(|| [*LOW_TICK, *MID_TICK, *HIGH_TICK]);
 
     #[test]
     fn test_impl_for_vec() {
-        let ticks = [LOW_TICK, MID_TICK, HIGH_TICK];
-        assert_eq!(ticks.binary_search_by_tick(-1), 0);
-        assert_eq!(ticks.binary_search_by_tick(0), 1);
-        assert_eq!(ticks.binary_search_by_tick(1), 1);
-        assert_eq!(ticks.binary_search_by_tick(MAX_TICK), 2);
+        assert_eq!(TICKS.binary_search_by_tick(-1), 0);
+        assert_eq!(TICKS.binary_search_by_tick(0), 1);
+        assert_eq!(TICKS.binary_search_by_tick(1), 1);
+        assert_eq!(TICKS.binary_search_by_tick(MAX_TICK), 2);
     }
 
     #[test]
     #[should_panic(expected = "ZERO_NET")]
     fn test_validate_list_zero_net() {
-        [LOW_TICK].validate_list(1);
+        [*LOW_TICK].validate_list(1);
     }
 
     #[test]
     #[should_panic(expected = "SORTED")]
     fn test_validate_list_unsorted() {
-        [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1);
+        [*HIGH_TICK, *LOW_TICK, *MID_TICK].validate_list(1);
     }
 
     #[test]
     #[should_panic(expected = "TICK_SPACING")]
     fn test_validate_list_tick_spacing() {
-        [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1337);
+        [*HIGH_TICK, *LOW_TICK, *MID_TICK].validate_list(1337);
     }
 
     #[test]
@@ -199,32 +199,32 @@ mod tests {
 
     #[test]
     fn test_next_initialized_tick_low_lte_true_2() {
-        assert_eq!(TICKS.next_initialized_tick(MIN_TICK + 1, true), &LOW_TICK);
-        assert_eq!(TICKS.next_initialized_tick(MIN_TICK + 2, true), &LOW_TICK);
+        assert_eq!(TICKS.next_initialized_tick(MIN_TICK + 1, true), &*LOW_TICK);
+        assert_eq!(TICKS.next_initialized_tick(MIN_TICK + 2, true), &*LOW_TICK);
     }
 
     #[test]
     fn test_next_initialized_tick_low_lte_false() {
-        assert_eq!(TICKS.next_initialized_tick(MIN_TICK, false), &LOW_TICK);
-        assert_eq!(TICKS.next_initialized_tick(MIN_TICK + 1, false), &MID_TICK);
+        assert_eq!(TICKS.next_initialized_tick(MIN_TICK, false), &*LOW_TICK);
+        assert_eq!(TICKS.next_initialized_tick(MIN_TICK + 1, false), &*MID_TICK);
     }
 
     #[test]
     fn test_next_initialized_tick_mid_lte_true() {
-        assert_eq!(TICKS.next_initialized_tick(0, true), &MID_TICK);
-        assert_eq!(TICKS.next_initialized_tick(1, true), &MID_TICK);
+        assert_eq!(TICKS.next_initialized_tick(0, true), &*MID_TICK);
+        assert_eq!(TICKS.next_initialized_tick(1, true), &*MID_TICK);
     }
 
     #[test]
     fn test_next_initialized_tick_mid_lte_false() {
-        assert_eq!(TICKS.next_initialized_tick(-1, false), &MID_TICK);
-        assert_eq!(TICKS.next_initialized_tick(1, false), &HIGH_TICK);
+        assert_eq!(TICKS.next_initialized_tick(-1, false), &*MID_TICK);
+        assert_eq!(TICKS.next_initialized_tick(1, false), &*HIGH_TICK);
     }
 
     #[test]
     fn test_next_initialized_tick_high_lte_true() {
-        assert_eq!(TICKS.next_initialized_tick(MAX_TICK - 1, true), &HIGH_TICK);
-        assert_eq!(TICKS.next_initialized_tick(MAX_TICK, true), &HIGH_TICK);
+        assert_eq!(TICKS.next_initialized_tick(MAX_TICK - 1, true), &*HIGH_TICK);
+        assert_eq!(TICKS.next_initialized_tick(MAX_TICK, true), &*HIGH_TICK);
     }
 
     #[test]
@@ -235,8 +235,14 @@ mod tests {
 
     #[test]
     fn test_next_initialized_tick_high_lte_false_2() {
-        assert_eq!(TICKS.next_initialized_tick(MAX_TICK - 2, false), &HIGH_TICK);
-        assert_eq!(TICKS.next_initialized_tick(MAX_TICK - 3, false), &HIGH_TICK);
+        assert_eq!(
+            TICKS.next_initialized_tick(MAX_TICK - 2, false),
+            &*HIGH_TICK
+        );
+        assert_eq!(
+            TICKS.next_initialized_tick(MAX_TICK - 3, false),
+            &*HIGH_TICK
+        );
     }
 
     #[test]


### PR DESCRIPTION
Adjusted the `Pool` and `Tick` structs and their methods to support generic index types, enhancing flexibility and type safety. This includes updating function signatures, trait bounds, and internal logic to utilize the new `TickIndex` trait, ensuring consistent behavior and eliminating the need for explicit integer types in tick operations.