### PR TITLE
feat(tickmap): add `TickMap` and `EphemeralTickMapDataProvider`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "0.39.0"
+version = "0.40.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/entities/tick.rs
+++ b/src/entities/tick.rs
@@ -2,7 +2,8 @@ use crate::prelude::*;
 use alloy_primitives::{aliases::I24, Signed};
 use core::{
     fmt::Debug,
-    ops::{Add, Div, Mul, Rem, Shl, Shr, Sub},
+    hash::Hash,
+    ops::{Add, BitAnd, Div, Mul, Rem, Shl, Shr, Sub},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -34,7 +35,9 @@ pub trait TickIndex:
     Copy
     + Debug
     + Default
+    + Hash
     + Ord
+    + BitAnd<Output = Self>
     + Add<Output = Self>
     + Div<Output = Self>
     + Mul<Output = Self>
@@ -65,6 +68,14 @@ pub trait TickIndex:
         } else {
             self / tick_spacing
         }
+    }
+
+    #[inline]
+    fn position(self) -> (Self, u8) {
+        (
+            self >> 8,
+            (self & Self::try_from(0xff).unwrap()).try_into().unwrap() as u8,
+        )
     }
 }
 

--- a/src/entities/tick_list_data_provider.rs
+++ b/src/entities/tick_list_data_provider.rs
@@ -39,7 +39,7 @@ mod tests {
     use once_cell::sync::Lazy;
 
     static PROVIDER: Lazy<TickListDataProvider> =
-        Lazy::new(|| TickListDataProvider::new(vec![Tick::new(-1, 1, -1), Tick::new(1, 1, 1)], 1));
+        Lazy::new(|| TickListDataProvider::new(vec![Tick::new(-1, 1, 1), Tick::new(1, 1, -1)], 1));
 
     #[test]
     fn can_take_an_empty_list_of_ticks() {
@@ -67,14 +67,14 @@ mod tests {
     #[test]
     fn gets_the_smallest_tick_from_the_list() {
         let tick = PROVIDER.get_tick(-1).unwrap();
-        assert_eq!(tick.liquidity_net, -1);
+        assert_eq!(tick.liquidity_net, 1);
         assert_eq!(tick.liquidity_gross, 1);
     }
 
     #[test]
     fn gets_the_largest_tick_from_the_list() {
         let tick = PROVIDER.get_tick(1).unwrap();
-        assert_eq!(tick.liquidity_net, 1);
+        assert_eq!(tick.liquidity_net, -1);
         assert_eq!(tick.liquidity_gross, 1);
     }
 }

--- a/src/extensions/ephemeral_tick_data_provider.rs
+++ b/src/extensions/ephemeral_tick_data_provider.rs
@@ -12,10 +12,9 @@ pub struct EphemeralTickDataProvider<I = I24> {
     pub pool: Address,
     pub tick_lower: I,
     pub tick_upper: I,
+    pub tick_spacing: I,
     pub block_id: Option<BlockId>,
     pub ticks: Vec<Tick<I>>,
-    /// the minimum distance between two ticks in the list
-    pub tick_spacing: I,
 }
 
 impl<I: TickIndex> EphemeralTickDataProvider<I> {
@@ -52,9 +51,9 @@ impl<I: TickIndex> EphemeralTickDataProvider<I> {
             pool,
             tick_lower: I::from_i24(tick_lower),
             tick_upper: I::from_i24(tick_upper),
+            tick_spacing: I::from_i24(tick_spacing),
             block_id,
             ticks,
-            tick_spacing: I::from_i24(tick_spacing),
         })
     }
 }
@@ -111,16 +110,16 @@ mod tests {
         let tick = provider.get_tick(-92110)?;
         assert_eq!(tick.liquidity_gross, 398290794261);
         assert_eq!(tick.liquidity_net, 398290794261);
-        let (tick, success) = provider.next_initialized_tick_within_one_word(
-            MIN_TICK.as_i32() + TICK_SPACING,
+        let (tick, initialized) = provider.next_initialized_tick_within_one_word(
+            MIN_TICK_I32 + TICK_SPACING,
             true,
             TICK_SPACING,
         )?;
-        assert!(success);
+        assert!(initialized);
         assert_eq!(tick, -887270);
-        let (tick, success) =
+        let (tick, initialized) =
             provider.next_initialized_tick_within_one_word(0, false, TICK_SPACING)?;
-        assert!(success);
+        assert!(initialized);
         assert_eq!(tick, 100);
         let provider: TickListDataProvider = provider.into();
         let tick = provider.get_tick(-92110)?;

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -10,7 +10,6 @@ use alloy::{
     transports::Transport,
 };
 use alloy_primitives::{Address, ChainId, B256};
-use anyhow::Result;
 use uniswap_lens::{
     bindings::{
         ierc20metadata::IERC20Metadata, iuniswapv3pool::IUniswapV3Pool::IUniswapV3PoolInstance,

--- a/src/extensions/tick_map.rs
+++ b/src/extensions/tick_map.rs
@@ -3,30 +3,85 @@
 //! supposedly more efficient than [`TickList`].
 
 use crate::prelude::*;
-use alloy_primitives::U256;
-use anyhow::Result;
+use alloy::uint;
+use alloy_primitives::{aliases::I24, U256};
 use rustc_hash::FxHashMap;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct TickMap {
-    pub bitmap: FxHashMap<i16, U256>,
-    pub ticks: FxHashMap<i32, Tick>,
+pub struct TickMap<I: TickIndex = I24> {
+    pub bitmap: FxHashMap<I, U256>,
+    pub inner: FxHashMap<I, Tick<I>>,
+    pub tick_spacing: I,
 }
 
-pub trait TickMapTrait {
-    type Tick;
-
+impl<I: TickIndex> TickMap<I> {
     #[inline]
     #[must_use]
-    fn position(tick: i32) -> (i16, u8) {
-        ((tick >> 8) as i16, (tick & 0xff) as u8)
+    pub fn new(ticks: Vec<Tick<I>>, tick_spacing: I) -> Self {
+        let mut bitmap = FxHashMap::<I, U256>::default();
+        for tick in &ticks {
+            let compressed = tick.index.compress(tick_spacing);
+            let (word_pos, bit_pos) = compressed.position();
+            let word = bitmap.get(&word_pos).unwrap_or(&U256::ZERO);
+            bitmap.insert(word_pos, word | uint!(1_U256) << bit_pos);
+        }
+        Self {
+            bitmap,
+            inner: FxHashMap::from_iter(ticks.into_iter().map(|tick| (tick.index, tick))),
+            tick_spacing,
+        }
     }
-
-    fn get_bitmap(&self, tick: i32) -> Result<U256>;
-
-    fn get_tick(&self, index: i32) -> &Self::Tick;
 }
 
-// impl TickMapTrait for TickMap {}
+impl<I: TickIndex> TickDataProvider for TickMap<I> {
+    type Index = I;
 
-pub trait TickMapDataProvider: TickMapTrait + TickDataProvider {}
+    #[inline]
+    fn get_tick(&self, tick: Self::Index) -> Result<&Tick<Self::Index>, Error> {
+        self.inner
+            .get(&tick)
+            .ok_or(Error::InvalidTick(tick.to_i24()))
+    }
+
+    #[inline]
+    fn next_initialized_tick_within_one_word(
+        &self,
+        tick: Self::Index,
+        lte: bool,
+        tick_spacing: Self::Index,
+    ) -> Result<(Self::Index, bool), Error> {
+        let compressed = tick.compress(tick_spacing);
+        if lte {
+            let (word_pos, bit_pos) = compressed.position();
+            // all the 1s at or to the right of the current `bit_pos`
+            // (2 << bitPos) may overflow but fine since 2 << 255 = 0
+            let mask = (TWO << bit_pos) - uint!(1_U256);
+            let word = self.bitmap.get(&word_pos).unwrap_or(&U256::ZERO);
+            let masked = word & mask;
+            let initialized = masked != U256::ZERO;
+            let bit_pos = if initialized {
+                let msb = masked.most_significant_bit() as u8;
+                (bit_pos - msb) as i32
+            } else {
+                bit_pos as i32
+            };
+            let next = (compressed - Self::Index::try_from(bit_pos).unwrap()) * tick_spacing;
+            Ok((next, initialized))
+        } else {
+            let (word_pos, bit_pos) = compressed.position();
+            // all the 1s at or to the left of the `bit_pos`
+            let mask = U256::ZERO - (uint!(1_U256) << bit_pos);
+            let word = self.bitmap.get(&word_pos).unwrap_or(&U256::ZERO);
+            let masked = word & mask;
+            let initialized = masked != U256::ZERO;
+            let bit_pos = if initialized {
+                let lsb = masked.least_significant_bit() as u8;
+                (lsb - bit_pos) as i32
+            } else {
+                (255 - bit_pos) as i32
+            };
+            let next = (compressed + Self::Index::try_from(bit_pos).unwrap()) * tick_spacing;
+            Ok((next, initialized))
+        }
+    }
+}

--- a/src/extensions/tick_map.rs
+++ b/src/extensions/tick_map.rs
@@ -18,6 +18,7 @@ impl<I: TickIndex> TickMap<I> {
     #[inline]
     #[must_use]
     pub fn new(ticks: Vec<Tick<I>>, tick_spacing: I) -> Self {
+        ticks.validate_list(tick_spacing);
         let mut bitmap = FxHashMap::<I, U256>::default();
         for tick in &ticks {
             let compressed = tick.index.compress(tick_spacing);

--- a/src/extensions/tick_map.rs
+++ b/src/extensions/tick_map.rs
@@ -1,6 +1,6 @@
 //! ## Tick Map
-//! [`TickMapTrait`] is a trait that provides a way to access tick data directly from a hashmap,
-//! supposedly more efficient than [`TickList`].
+//! [`TickMap`] provides a way to access tick data directly from a hashmap, supposedly more
+//! efficient than [`TickList`].
 
 use crate::prelude::*;
 use alloy::uint;

--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -71,7 +71,7 @@ impl<I: TickIndex> TickList for [Tick<I>] {
         assert_eq!(
             self.iter().fold(0_u128, |acc, x| acc
                 .checked_add_signed(x.liquidity_net)
-                .unwrap()),
+                .expect("ZERO_NET")),
             0,
             "ZERO_NET"
         );

--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -69,7 +69,9 @@ impl<I: TickIndex> TickList for [Tick<I>] {
             assert!(self[i] >= self[i - 1], "SORTED");
         }
         assert_eq!(
-            self.iter().fold(0, |acc, x| acc + x.liquidity_net),
+            self.iter().fold(0_u128, |acc, x| acc
+                .checked_add_signed(x.liquidity_net)
+                .unwrap()),
             0,
             "ZERO_NET"
         );


### PR DESCRIPTION
Introduce `TickMap` to efficiently handle tick data with specified spacing. Additionally, implement `EphemeralTickMapDataProvider` for fetching ticks using ephemeral contracts, enhancing tick data management and retrieval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the `uniswap-v3-sdk` package to version 0.40.0, introducing potential new features and improvements.
	- Enhanced `TickIndex` trait with new methods and capabilities for better data handling.
	- Improved `EphemeralTickMapDataProvider` for flexible tick index types and added functionality for tick retrieval.
	- Introduced a new `TickMap` structure with enhanced tick management and retrieval methods.

- **Bug Fixes**
	- Streamlined initialization processes and removed redundant declarations for better clarity.
	- Enhanced assertion logic in `TickList` to prevent overflow during liquidity net calculations.

- **Documentation**
	- Updated test modules to validate the functionality of new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->