### PR TITLE
chore: bump version to 1.0.0 and adjust `once_cell` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "1.0.0-rc"
+version = "1.0.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -23,7 +23,7 @@ bigdecimal = "0.4.5"
 num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"
-once_cell = "1.20"
+once_cell = "1.19"
 regex = { version = "1.10", optional = true }
 rustc-hash = "2.0"
 serde_json = { version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "1.0.0-rc", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "1.0.0", features = ["extensions", "std"] }
 ```
 
 ### Usage


### PR DESCRIPTION
Change the package version from 1.0.0-rc to 1.0.0 in Cargo.toml and README.md. Also, update the once_cell dependency from version 1.20 to 1.19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned the package to a stable release version, indicating readiness for production use.
  
- **Bug Fixes**
	- Downgraded the `once_cell` dependency to ensure compatibility and resolve issues with the previous version.

- **Chores**
	- Updated the `uniswap-v3-sdk` dependency to its stable version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->