### PR TITLE
refactor: `to_big_decimal` as default trait implementation

### DIFF
--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -4,8 +4,13 @@ use num_bigint::{BigInt, BigUint, Sign};
 
 pub trait ToBig {
     fn to_big_uint(&self) -> BigUint;
+
     fn to_big_int(&self) -> BigInt;
-    fn to_big_decimal(&self) -> BigDecimal;
+
+    #[inline]
+    fn to_big_decimal(&self) -> BigDecimal {
+        BigDecimal::from(self.to_big_int())
+    }
 }
 
 impl<const BITS: usize, const LIMBS: usize> ToBig for Uint<BITS, LIMBS> {
@@ -18,11 +23,6 @@ impl<const BITS: usize, const LIMBS: usize> ToBig for Uint<BITS, LIMBS> {
     fn to_big_int(&self) -> BigInt {
         BigInt::from_biguint(Sign::Plus, self.to_big_uint())
     }
-
-    #[inline]
-    fn to_big_decimal(&self) -> BigDecimal {
-        BigDecimal::from(self.to_big_int())
-    }
 }
 
 impl<const BITS: usize, const LIMBS: usize> ToBig for Signed<BITS, LIMBS> {
@@ -34,11 +34,6 @@ impl<const BITS: usize, const LIMBS: usize> ToBig for Signed<BITS, LIMBS> {
     #[inline]
     fn to_big_int(&self) -> BigInt {
         BigInt::from_signed_bytes_le(&self.into_raw().as_le_bytes())
-    }
-
-    #[inline]
-    fn to_big_decimal(&self) -> BigDecimal {
-        BigDecimal::from(self.to_big_int())
     }
 }
 


### PR DESCRIPTION
Moved the `to_big_decimal` implementation into the `ToBig` trait definition as a default method. This avoids code duplication and simplifies the `Uint` and `Signed` implementations by leveraging the shared logic directly in the trait.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optimized method for converting integers to `BigDecimal`, enhancing performance and maintainability.
  
- **Bug Fixes**
	- Eliminated redundant implementations of the conversion method, reducing complexity and potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->