### PR TITLE
refactor: use `Self` for constructors and conversions

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -63,7 +63,7 @@ impl From<i32> for FeeAmount {
 impl From<FeeAmount> for U24 {
     #[inline]
     fn from(fee: FeeAmount) -> Self {
-        U24::from_limbs([fee as u64])
+        Self::from_limbs([fee as u64])
     }
 }
 

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -429,7 +429,7 @@ impl<TP: Clone + TickDataProvider> Pool<TP> {
         };
         Ok((
             CurrencyAmount::from_raw_amount(output_token, -output_amount.to_big_int())?,
-            Pool::new_with_tick_data_provider(
+            Self::new_with_tick_data_provider(
                 self.token0.clone(),
                 self.token1.clone(),
                 self.fee,
@@ -484,7 +484,7 @@ impl<TP: Clone + TickDataProvider> Pool<TP> {
         };
         Ok((
             CurrencyAmount::from_raw_amount(input_token, input_amount.to_big_int())?,
-            Pool::new_with_tick_data_provider(
+            Self::new_with_tick_data_provider(
                 self.token0.clone(),
                 self.token1.clone(),
                 self.fee,

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -60,7 +60,7 @@ where
         }
         assert!(current_input_token.equals(wrapped_output), "PATH");
 
-        Route {
+        Self {
             pools,
             input,
             output,

--- a/src/entities/tick.rs
+++ b/src/entities/tick.rs
@@ -95,8 +95,8 @@ impl TickIndex for i32 {
 }
 
 impl<const BITS: usize, const LIMBS: usize> TickIndex for Signed<BITS, LIMBS> {
-    const ZERO: Self = Signed::ZERO;
-    const ONE: Self = Signed::ONE;
+    const ZERO: Self = Self::ZERO;
+    const ONE: Self = Self::ONE;
 
     #[inline]
     fn from_i24(value: I24) -> Self {

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -103,7 +103,7 @@ where
         input_amount: CurrencyAmount<TInput>,
         output_amount: CurrencyAmount<TOutput>,
     ) -> Self {
-        Swap {
+        Self {
             route,
             input_amount,
             output_amount,
@@ -189,7 +189,7 @@ where
             }
         }
         assert_eq!(num_pools, pool_address_set.len(), "POOLS_DUPLICATED");
-        Ok(Trade {
+        Ok(Self {
             swaps,
             trade_type,
             _input_amount: None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,7 +74,7 @@ pub enum Error {
 impl From<CoreError> for Error {
     #[inline]
     fn from(error: CoreError) -> Self {
-        Error::Core(error)
+        Self::Core(error)
     }
 }
 
@@ -82,7 +82,7 @@ impl From<CoreError> for Error {
 impl From<ContractError> for Error {
     #[inline]
     fn from(error: ContractError) -> Self {
-        Error::ContractError(error)
+        Self::ContractError(error)
     }
 }
 
@@ -90,6 +90,6 @@ impl From<ContractError> for Error {
 impl From<LensError> for Error {
     #[inline]
     fn from(error: LensError) -> Self {
-        Error::LensError(error)
+        Self::LensError(error)
     }
 }

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -139,7 +139,7 @@ impl Position {
             slot0.sqrtPriceX96,
             active_liquidity,
         )?;
-        Ok(Position::new(
+        Ok(Self::new(
             pool,
             position.liquidity,
             position.tickLower.as_i32(),
@@ -199,7 +199,7 @@ impl<I: TickIndex> Position<EphemeralTickMapDataProvider<I>> {
             pool.liquidity,
             tick_data_provider,
         )?;
-        Ok(Position::new(
+        Ok(Self::new(
             pool,
             position.liquidity,
             position.tick_lower.try_into().unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
     clippy::unseparated_literal_suffix,
     clippy::unused_self,
     clippy::use_debug,
+    clippy::use_self,
     rustdoc::all
 )]
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]


### PR DESCRIPTION
This change replaces explicit struct names with `Self` in constructor and conversion implementations. It improves readability and follows best practices for Rust's self-referential code. The update also enables the `clippy::use_self` lint to enforce these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new linting rule to enhance code clarity by enforcing the use of `Self` in method implementations.

- **Refactor**
	- Streamlined method calls and structure instantiations across various entities by replacing explicit type references with `Self`, improving code readability and maintainability.

- **Bug Fixes**
	- Updated error handling methods to simplify syntax without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->