### PR TITLE
refactor: add `derive_more` and remove manual trait impls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ alloy-sol-types = "0.8"
 anyhow = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true }
 bigdecimal = "0.4.5"
+derive_more = { version = "1.0.0", features = ["deref", "from"] }
 num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"

--- a/src/entities/tick_list_data_provider.rs
+++ b/src/entities/tick_list_data_provider.rs
@@ -1,8 +1,8 @@
 use crate::prelude::*;
-use core::ops::Deref;
+use derive_more::Deref;
 
 /// A data provider for ticks that is backed by an in-memory array of ticks.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Deref)]
 pub struct TickListDataProvider<I = i32>(Vec<Tick<I>>);
 
 impl<I: TickIndex> TickListDataProvider<I> {
@@ -10,15 +10,6 @@ impl<I: TickIndex> TickListDataProvider<I> {
     pub fn new(ticks: Vec<Tick<I>>, tick_spacing: I) -> Self {
         ticks.validate_list(tick_spacing);
         Self(ticks)
-    }
-}
-
-impl<I> Deref for TickListDataProvider<I> {
-    type Target = Vec<Tick<I>>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,18 +7,16 @@ use alloy::contract::Error as ContractError;
 use uniswap_lens::error::Error as LensError;
 
 use alloy_primitives::{aliases::I24, U160};
+use derive_more::From;
 use uniswap_sdk_core::error::Error as CoreError;
 
-#[cfg_attr(
-    not(feature = "extensions"),
-    derive(Clone, Copy, Debug, Hash, PartialEq, Eq)
-)]
-#[cfg_attr(feature = "extensions", derive(Debug))]
+#[derive(Debug, From)]
+#[cfg_attr(not(feature = "extensions"), derive(Clone, Copy, Hash, PartialEq, Eq))]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum Error {
     /// Thrown when an error occurs in the core library.
     #[cfg_attr(feature = "std", error("{0}"))]
-    Core(CoreError),
+    Core(#[cfg_attr(not(feature = "std"), from)] CoreError),
 
     /// Thrown when the token passed to [`Pool::price_of`] is not one of the pool's tokens.
     #[cfg_attr(feature = "std", error("Invalid token"))]
@@ -64,32 +62,9 @@ pub enum Error {
 
     #[cfg(feature = "extensions")]
     #[cfg_attr(feature = "std", error("{0}"))]
-    ContractError(ContractError),
+    ContractError(#[cfg_attr(not(feature = "std"), from)] ContractError),
 
     #[cfg(feature = "extensions")]
     #[cfg_attr(feature = "std", error("{0}"))]
-    LensError(LensError),
-}
-
-impl From<CoreError> for Error {
-    #[inline]
-    fn from(error: CoreError) -> Self {
-        Self::Core(error)
-    }
-}
-
-#[cfg(feature = "extensions")]
-impl From<ContractError> for Error {
-    #[inline]
-    fn from(error: ContractError) -> Self {
-        Self::ContractError(error)
-    }
-}
-
-#[cfg(feature = "extensions")]
-impl From<LensError> for Error {
-    #[inline]
-    fn from(error: LensError) -> Self {
-        Self::LensError(error)
-    }
+    LensError(#[cfg_attr(not(feature = "std"), from)] LensError),
 }

--- a/src/extensions/ephemeral_tick_data_provider.rs
+++ b/src/extensions/ephemeral_tick_data_provider.rs
@@ -4,17 +4,18 @@
 use crate::prelude::*;
 use alloy::{eips::BlockId, providers::Provider, transports::Transport};
 use alloy_primitives::{aliases::I24, Address};
-use core::ops::Deref;
+use derive_more::Deref;
 use uniswap_lens::pool_lens;
 
 /// A data provider that fetches ticks using an ephemeral contract in a single `eth_call`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deref)]
 pub struct EphemeralTickDataProvider<I = I24> {
     pub pool: Address,
     pub tick_lower: I,
     pub tick_upper: I,
     pub tick_spacing: I,
     pub block_id: Option<BlockId>,
+    #[deref]
     pub ticks: Vec<Tick<I>>,
 }
 
@@ -56,15 +57,6 @@ impl<I: TickIndex> EphemeralTickDataProvider<I> {
             block_id,
             ticks,
         })
-    }
-}
-
-impl<I> Deref for EphemeralTickDataProvider<I> {
-    type Target = Vec<Tick<I>>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.ticks
     }
 }
 

--- a/src/extensions/ephemeral_tick_map_data_provider.rs
+++ b/src/extensions/ephemeral_tick_map_data_provider.rs
@@ -4,16 +4,17 @@
 use crate::prelude::*;
 use alloy::{eips::BlockId, providers::Provider, transports::Transport};
 use alloy_primitives::{aliases::I24, Address};
-use core::ops::Deref;
+use derive_more::Deref;
 
 /// A data provider that fetches ticks using an ephemeral contract in a single `eth_call`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deref)]
 pub struct EphemeralTickMapDataProvider<I = I24> {
     pub pool: Address,
     pub tick_lower: I,
     pub tick_upper: I,
     pub tick_spacing: I,
     pub block_id: Option<BlockId>,
+    #[deref]
     pub tick_map: TickMap<I>,
 }
 
@@ -41,15 +42,6 @@ impl<I: TickIndex> EphemeralTickMapDataProvider<I> {
             block_id,
             tick_map: TickMap::new(provider.ticks, provider.tick_spacing),
         })
-    }
-}
-
-impl<I> Deref for EphemeralTickMapDataProvider<I> {
-    type Target = TickMap<I>;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.tick_map
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the `derive_more` dependency to enhance functionality with automatic dereferencing for `TickListDataProvider`, `EphemeralTickDataProvider`, and `EphemeralTickMapDataProvider`.
	- Streamlined error handling with automatic conversions in the `Error` enum.

- **Bug Fixes**
	- Simplified access to tick data structures by removing manual implementations of the `Deref` trait.

- **Refactor**
	- Updated struct signatures to include the `Deref` trait, improving usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->