### PR TITLE
refactor!: change `Currency` to `BaseCurrency` for parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "1.2.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -30,7 +30,7 @@ rustc-hash = "2.0"
 serde_json = { version = "1.0", optional = true }
 thiserror = { version = "1.0", optional = true }
 uniswap-lens = { version = "0.4", optional = true }
-uniswap-sdk-core = "2.4.0"
+uniswap-sdk-core = "3.0.0"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "1.2.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "2.0.0", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -166,7 +166,7 @@ impl<TP: TickDataProvider> Pool<TP> {
     ///
     /// returns: bool
     #[inline]
-    pub fn involves_token(&self, token: &impl Currency) -> bool {
+    pub fn involves_token(&self, token: &impl BaseCurrency) -> bool {
         self.token0.equals(token) || self.token1.equals(token)
     }
 
@@ -284,7 +284,7 @@ impl<TP: Clone + TickDataProvider> Pool<TP> {
     #[inline]
     pub fn get_output_amount(
         &self,
-        input_amount: &CurrencyAmount<impl Currency>,
+        input_amount: &CurrencyAmount<impl BaseCurrency>,
         sqrt_price_limit_x96: Option<U160>,
     ) -> Result<(CurrencyAmount<&Token>, Self), Error> {
         assert!(self.involves_token(&input_amount.currency), "TOKEN");
@@ -339,7 +339,7 @@ impl<TP: Clone + TickDataProvider> Pool<TP> {
     #[inline]
     pub fn get_input_amount(
         &self,
-        output_amount: &CurrencyAmount<impl Currency>,
+        output_amount: &CurrencyAmount<impl BaseCurrency>,
         sqrt_price_limit_x96: Option<U160>,
     ) -> Result<(CurrencyAmount<&Token>, Self), Error> {
         assert!(self.involves_token(&output_amount.currency), "TOKEN");

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -6,8 +6,8 @@ use uniswap_sdk_core::prelude::*;
 #[derive(Clone, PartialEq, Debug)]
 pub struct Route<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     pub pools: Vec<Pool<TP>>,
@@ -20,8 +20,8 @@ where
 
 impl<TInput, TOutput, TP> Route<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     /// Creates an instance of route.

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -15,8 +15,8 @@ pub fn trade_comparator<TInput, TOutput, TP>(
     b: &Trade<TInput, TOutput, TP>,
 ) -> Ordering
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     // must have same input and output token for comparison
@@ -75,8 +75,8 @@ pub struct BestTradeOptions {
 #[derive(Clone, PartialEq, Debug)]
 pub struct Swap<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     pub route: Route<TInput, TOutput, TP>,
@@ -86,8 +86,8 @@ where
 
 impl<TInput, TOutput, TP> Swap<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     /// Constructs a swap
@@ -133,8 +133,8 @@ where
 #[derive(Clone, PartialEq, Debug)]
 pub struct Trade<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     /// The swaps of the trade, i.e. which routes and how much is swapped in each that make up the
@@ -154,8 +154,8 @@ where
 
 impl<TInput, TOutput, TP> Trade<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     /// Construct a trade by passing in the pre-computed property values
@@ -497,8 +497,8 @@ where
 
 impl<TInput, TOutput, TP> Trade<TInput, TOutput, TP>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: Clone + TickDataProvider,
 {
     /// Constructs an exact in trade with the given amount in and route
@@ -539,7 +539,7 @@ where
     #[inline]
     pub fn from_route(
         route: Route<TInput, TOutput, TP>,
-        amount: CurrencyAmount<impl Currency>,
+        amount: CurrencyAmount<impl BaseCurrency>,
         trade_type: TradeType,
     ) -> Result<Self, Error> {
         let mut token_amount: CurrencyAmount<&Token> = amount.wrapped()?;
@@ -600,7 +600,10 @@ where
     /// * `trade_type`: Whether the trade is an exact input or exact output swap
     #[inline]
     pub fn from_routes(
-        routes: Vec<(CurrencyAmount<impl Currency>, Route<TInput, TOutput, TP>)>,
+        routes: Vec<(
+            CurrencyAmount<impl BaseCurrency>,
+            Route<TInput, TOutput, TP>,
+        )>,
         trade_type: TradeType,
     ) -> Result<Self, Error> {
         let mut populated_routes: Vec<Swap<TInput, TOutput, TP>> = Vec::with_capacity(routes.len());

--- a/src/extensions/price_tick_conversions.rs
+++ b/src/extensions/price_tick_conversions.rs
@@ -52,8 +52,8 @@ pub fn parse_price<TBase, TQuote>(
     price: &str,
 ) -> Result<Price<TBase, TQuote>>
 where
-    TBase: Currency,
-    TQuote: Currency,
+    TBase: BaseCurrency,
+    TQuote: BaseCurrency,
 {
     // Check whether `price` is a valid string of decimal number.
     // This regex matches any number of digits optionally followed by '.' which is then followed by

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -53,7 +53,7 @@ pub struct SafeTransferOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CollectOptions<Currency0: Currency, Currency1: Currency> {
+pub struct CollectOptions<Currency0: BaseCurrency, Currency1: BaseCurrency> {
     /// Indicates the ID of the position to collect for.
     pub token_id: U256,
     /// Expected value of tokensOwed0, including as-of-yet-unaccounted-for fees/liquidity value to
@@ -75,7 +75,7 @@ pub struct NFTPermitOptions {
 
 /// Options for producing the calldata to exit a position.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct RemoveLiquidityOptions<Currency0: Currency, Currency1: Currency> {
+pub struct RemoveLiquidityOptions<Currency0: BaseCurrency, Currency1: BaseCurrency> {
     /// The ID of the token to exit
     pub token_id: U256,
     /// The percentage of position liquidity to exit.
@@ -217,7 +217,7 @@ pub fn add_call_parameters<TP: TickDataProvider>(
     })
 }
 
-fn encode_collect<Currency0: Currency, Currency1: Currency>(
+fn encode_collect<Currency0: BaseCurrency, Currency1: BaseCurrency>(
     options: &CollectOptions<Currency0, Currency1>,
 ) -> Vec<Bytes> {
     let mut calldatas: Vec<Bytes> = Vec::with_capacity(3);
@@ -269,7 +269,7 @@ fn encode_collect<Currency0: Currency, Currency1: Currency>(
 }
 
 #[inline]
-pub fn collect_call_parameters<Currency0: Currency, Currency1: Currency>(
+pub fn collect_call_parameters<Currency0: BaseCurrency, Currency1: BaseCurrency>(
     options: &CollectOptions<Currency0, Currency1>,
 ) -> MethodParameters {
     let calldatas = encode_collect(options);
@@ -292,8 +292,8 @@ pub fn remove_call_parameters<Currency0, Currency1, TP>(
     options: RemoveLiquidityOptions<Currency0, Currency1>,
 ) -> Result<MethodParameters, Error>
 where
-    Currency0: Currency,
-    Currency1: Currency,
+    Currency0: BaseCurrency,
+    Currency1: BaseCurrency,
     TP: TickDataProvider,
 {
     let mut calldatas: Vec<Bytes> = Vec::with_capacity(6);

--- a/src/quoter.rs
+++ b/src/quoter.rs
@@ -24,13 +24,13 @@ pub struct QuoteOptions {
 #[inline]
 pub fn quote_call_parameters<TInput, TOutput, TP>(
     route: &Route<TInput, TOutput, TP>,
-    amount: &CurrencyAmount<impl Currency>,
+    amount: &CurrencyAmount<impl BaseCurrency>,
     trade_type: TradeType,
     options: Option<QuoteOptions>,
 ) -> MethodParameters
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     let options = options.unwrap_or_default();

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -33,8 +33,8 @@ pub fn swap_call_parameters<TInput, TOutput, TP>(
     options: SwapOptions,
 ) -> Result<MethodParameters, Error>
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     let SwapOptions {

--- a/src/utils/encode_route_to_path.rs
+++ b/src/utils/encode_route_to_path.rs
@@ -31,8 +31,8 @@ pub fn encode_route_to_path<TInput, TOutput, TP>(
     exact_output: bool,
 ) -> Bytes
 where
-    TInput: Currency,
-    TOutput: Currency,
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
     TP: TickDataProvider,
 {
     let mut path: Vec<u8> = Vec::with_capacity(23 * route.pools.len() + 20);


### PR DESCRIPTION
Updated type constraints from `Currency` to `BaseCurrency` across various modules and methods. This change ensures consistency and aligns with the new type naming convention. Also bumped the version to 2.0.0 to reflect the breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 2.0.0 for the Uniswap V3 SDK.
	- Enhanced type safety by refining currency handling across various components.

- **Bug Fixes**
	- Improved type constraints in multiple methods and structs to ensure compatibility with the new `BaseCurrency` type.

- **Documentation**
	- Updated installation instructions in the README to reflect the new SDK version.

- **Chores**
	- General maintenance and updates to ensure consistency across the codebase with the new type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->