### PR TITLE
feat: Add EIP712 signing support for NFT permits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ extensions = ["uniswap-lens/std", "alloy", "anyhow", "base64", "regex", "serde_j
 std = ["thiserror", "uniswap-sdk-core/std"]
 
 [dev-dependencies]
+alloy-signer = "0.4"
+alloy-signer-local = "0.4"
 criterion = "0.5.1"
 dotenv = "0.15.0"
 tokio = { version = "1.40", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -445,7 +445,9 @@ pub fn safe_transfer_from_parameters(options: SafeTransferOptions) -> MethodPara
 /// ## Examples
 ///
 /// ```
-/// use alloy_primitives::{address, b256, uint, B256};
+/// use alloy_primitives::{address, b256, uint, Signature, B256};
+/// use alloy_signer::SignerSync;
+/// use alloy_signer_local::PrivateKeySigner;
 /// use alloy_sol_types::SolStruct;
 /// use uniswap_v3_sdk::prelude::*;
 ///
@@ -461,8 +463,16 @@ pub fn safe_transfer_from_parameters(options: SafeTransferOptions) -> MethodPara
 /// );
 /// let position_manager = address!("1F98431c8aD98523631AE4a59f267346ea31F984");
 /// let data: NFTPermitData = get_permit_data(permit, position_manager, 1);
+///
 /// // Derive the EIP-712 signing hash.
 /// let hash: B256 = data.values.eip712_signing_hash(&data.domain);
+///
+/// let signer = PrivateKeySigner::random();
+/// let signature: Signature = signer.sign_hash_sync(&hash).unwrap();
+/// assert_eq!(
+///     signature.recover_address_from_prehash(&hash).unwrap(),
+///     signer.address()
+/// );
 /// ```
 #[inline]
 #[must_use]


### PR DESCRIPTION
Implemented `Permit` struct and `NFTPermitData` to facilitate EIP712 domain and value handling. Added `get_permit_data` function to prepare parameters for EIP712 signing, enhancing interoperability and security for non-fungible token (NFT) permits.

Expanded the example in `nonfungible_position_manager.rs` to include EIP-712 signing using `alloy-signer-local`. Updated dependencies in `Cargo.toml` to include `alloy-signer-local` version 0.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 2.1.0, enhancing overall functionality.
	- Introduced new EIP712 signing capabilities for NFT permits, improving security and usability.
	- Added new data structures to support permit handling.

- **Documentation**
	- Enhanced documentation for the new `get_permit_data` function, providing clear usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->