### PR TITLE
feat: add multicall decoding

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,8 @@ mod tests;
 
 pub mod prelude {
     pub use crate::{
-        abi::*, constants::*, entities::*, error::*, multicall::encode_multicall,
-        nonfungible_position_manager::*, payments::*, quoter::*, self_permit::*, staker::*,
-        swap_router::*, utils::*,
+        abi::*, constants::*, entities::*, error::*, multicall::*, nonfungible_position_manager::*,
+        payments::*, quoter::*, self_permit::*, staker::*, swap_router::*, utils::*,
     };
     pub use alloc::{
         string::{String, ToString},

--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -12,26 +12,58 @@ pub fn encode_multicall(data: Vec<Bytes>) -> Bytes {
     }
 }
 
+#[inline]
+#[must_use]
+pub fn decode_multicall(encoded: &Bytes) -> Vec<Bytes> {
+    IMulticall::multicallCall::abi_decode(encoded.as_ref(), true)
+        .unwrap()
+        .data
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use alloy_primitives::hex;
 
-    #[test]
-    fn test_encode_multicall_string_array_len_1() {
-        let calldata = encode_multicall(vec![vec![0x01].into()]);
-        assert_eq!(calldata, vec![0x01]);
+    mod encode {
+        use super::*;
+
+        #[test]
+        fn test_string_array_len_1() {
+            let calldata = encode_multicall(vec![vec![0x01].into()]);
+            assert_eq!(calldata, vec![0x01]);
+        }
+
+        #[test]
+        fn test_string_array_len_2() {
+            let calldata = encode_multicall(vec![
+                hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").into(),
+                hex!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").into(),
+            ]);
+            assert_eq!(
+                calldata.to_vec(),
+                hex!("ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+            );
+        }
     }
 
-    #[test]
-    fn test_encode_multicall_string_array_len_2() {
-        let calldata = encode_multicall(vec![
-            hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").into(),
-            hex!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").into(),
-        ]);
-        assert_eq!(
-            calldata.to_vec(),
-            hex!("ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
-        );
+    mod decode {
+        use super::*;
+
+        #[test]
+        fn test_string_array_len_2() {
+            let calldatas = vec![
+                hex!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa").into(),
+                hex!("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb").into(),
+            ];
+            let multicall = encode_multicall(calldatas.clone());
+            assert_eq!(
+                multicall.to_vec(),
+                hex!("ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+            );
+
+            let decoded_calldata = decode_multicall(&multicall);
+            assert_eq!(decoded_calldata, calldatas);
+        }
     }
 }

--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -1,6 +1,6 @@
 use crate::prelude::*;
 use alloy_primitives::Bytes;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{Error, SolCall};
 
 #[inline]
 #[must_use]
@@ -13,11 +13,8 @@ pub fn encode_multicall(data: Vec<Bytes>) -> Bytes {
 }
 
 #[inline]
-#[must_use]
-pub fn decode_multicall(encoded: &Bytes) -> Vec<Bytes> {
-    IMulticall::multicallCall::abi_decode(encoded.as_ref(), true)
-        .unwrap()
-        .data
+pub fn decode_multicall(encoded: &Bytes) -> Result<Vec<Bytes>, Error> {
+    IMulticall::multicallCall::abi_decode(encoded.as_ref(), true).map(|decoded| decoded.data)
 }
 
 #[cfg(test)]
@@ -62,7 +59,7 @@ mod tests {
                 hex!("ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
             );
 
-            let decoded_calldata = decode_multicall(&multicall);
+            let decoded_calldata = decode_multicall(&multicall).unwrap();
             assert_eq!(decoded_calldata, calldatas);
         }
     }


### PR DESCRIPTION
Introduce `decode_multicall` function to decode encoded multicall data. Reorganized tests into `encode` and `decode` modules for clarity and thorough testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new function for decoding multicall data, enhancing the ability to process encoded information.
- **Refactor**
	- Streamlined import statements for improved code organization without impacting functionality.
- **Tests**
	- Reorganized test modules, adding dedicated tests for the new decoding functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->