### PR TITLE
feat: refactor permit types and add ERC20 permit support

### DIFF
--- a/src/abi.rs
+++ b/src/abi.rs
@@ -79,6 +79,20 @@ sol! {
 
         function burn(uint256 tokenId) external payable;
 
+        function safeTransferFrom(address from, address to, uint256 tokenId) external;
+
+        function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+    }
+
+    interface IERC721Permit {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Permit {
+            address spender;
+            uint256 tokenId;
+            uint256 nonce;
+            uint256 deadline;
+        }
+
         function permit(
             address spender,
             uint256 tokenId,
@@ -87,15 +101,33 @@ sol! {
             bytes32 r,
             bytes32 s
         ) external payable;
-
-        function safeTransferFrom(address from, address to, uint256 tokenId) external;
-
-        function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
     }
 
     interface ISelfPermit {
         function selfPermit(address token, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external payable;
         function selfPermitAllowed(address token, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) external payable;
+    }
+
+    interface IERC20Permit {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Permit {
+            address owner;
+            address spender;
+            uint256 value;
+            uint256 nonce;
+            uint256 deadline;
+        }
+    }
+
+    interface IDaiPermit {
+        #[derive(Debug, PartialEq, Eq)]
+        struct Permit {
+            address holder;
+            address spender;
+            uint256 nonce;
+            uint256 expiry;
+            bool allowed;
+        }
     }
 
     interface IPeripheryPaymentsWithFee {

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -1,6 +1,6 @@
 use crate::prelude::{Error, *};
 use alloy_primitives::{Bytes, Signature, U256};
-use alloy_sol_types::{eip712_domain, sol, Eip712Domain, SolCall};
+use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall};
 use uniswap_sdk_core::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -66,20 +66,10 @@ pub struct CollectOptions<Currency0: BaseCurrency, Currency1: BaseCurrency> {
     pub recipient: Address,
 }
 
-sol! {
-    #[derive(Debug, PartialEq, Eq)]
-    struct Permit {
-        address spender;
-        uint256 tokenId;
-        uint256 nonce;
-        uint256 deadline;
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NFTPermitData {
     pub domain: Eip712Domain,
-    pub values: Permit,
+    pub values: IERC721Permit::Permit,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -341,7 +331,7 @@ where
 
     if let Some(permit) = options.permit {
         calldatas.push(
-            INonfungiblePositionManager::permitCall {
+            IERC721Permit::permitCall {
                 spender: permit.spender,
                 tokenId: token_id,
                 deadline: permit.deadline,
@@ -451,7 +441,7 @@ pub fn safe_transfer_from_parameters(options: SafeTransferOptions) -> MethodPara
 /// use alloy_sol_types::SolStruct;
 /// use uniswap_v3_sdk::prelude::*;
 ///
-/// let permit = Permit {
+/// let permit = IERC721Permit::Permit {
 ///     spender: address!("0000000000000000000000000000000000000002"),
 ///     tokenId: uint!(1_U256),
 ///     nonce: uint!(1_U256),
@@ -477,7 +467,7 @@ pub fn safe_transfer_from_parameters(options: SafeTransferOptions) -> MethodPara
 #[inline]
 #[must_use]
 pub const fn get_permit_data(
-    permit: Permit,
+    permit: IERC721Permit::Permit,
     position_manager: Address,
     chain_id: u64,
 ) -> NFTPermitData {

--- a/src/self_permit.rs
+++ b/src/self_permit.rs
@@ -1,10 +1,10 @@
 use super::abi::ISelfPermit;
 use alloy_primitives::{Bytes, Signature, U256};
-use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall};
+use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall, SolStruct};
 use uniswap_sdk_core::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ERC20PermitData<P> {
+pub struct ERC20PermitData<P: SolStruct> {
     pub domain: Eip712Domain,
     pub values: P,
 }
@@ -75,7 +75,7 @@ pub struct ERC20PermitData<P> {
 /// ```
 #[inline]
 #[must_use]
-pub fn get_erc20_permit_data<P>(
+pub fn get_erc20_permit_data<P: SolStruct>(
     permit: P,
     name: &'static str,
     version: &'static str,


### PR DESCRIPTION
Replaced custom `Permit` structs with standardized ones like `IERC721Permit::Permit` and `IERC20Permit::Permit`. This change enhances compatibility with token contracts and simplifies permit data handling. Also introduced a helper function for generating EIP-2612 domain and values for ERC20 permits.

Closes #54.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for safe transfer of non-fungible tokens (NFTs).
	- Added interfaces for ERC721 and ERC20 permits, enhancing token transfer approval mechanisms.
	- Introduced a structured way to handle EIP-712 domain data for ERC20 permits.

- **Bug Fixes**
	- Updated existing structures for better clarity and consistency in permit handling.

- **Documentation**
	- Enhanced documentation for new functionalities related to token management and permits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->