### PR TITLE
fix(tick_map): fix `next_initialized_tick_within_one_word`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "2.0.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "2.1.1", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/src/extensions/ephemeral_tick_map_data_provider.rs
+++ b/src/extensions/ephemeral_tick_map_data_provider.rs
@@ -63,6 +63,7 @@ mod tests {
             *BLOCK_ID,
         )
         .await?;
+        // [-887270, -92110, 100, 110, 22990, ...]
         let tick = provider.get_tick(-92110)?;
         assert_eq!(tick.liquidity_gross, 398290794261);
         assert_eq!(tick.liquidity_net, 398290794261);
@@ -74,9 +75,17 @@ mod tests {
         assert_eq!(tick, -887270);
         assert!(initialized);
         let (tick, initialized) =
+            provider.next_initialized_tick_within_one_word(-92120, true, TICK_SPACING)?;
+        assert_eq!(tick, -92160);
+        assert!(!initialized);
+        let (tick, initialized) =
             provider.next_initialized_tick_within_one_word(0, false, TICK_SPACING)?;
-        assert!(initialized);
         assert_eq!(tick, 100);
+        assert!(initialized);
+        let (tick, initialized) =
+            provider.next_initialized_tick_within_one_word(110, false, TICK_SPACING)?;
+        assert_eq!(tick, 2550);
+        assert!(!initialized);
         Ok(())
     }
 }

--- a/src/extensions/tick_map.rs
+++ b/src/extensions/tick_map.rs
@@ -69,6 +69,8 @@ impl<I: TickIndex> TickDataProvider for TickMap<I> {
             let next = (compressed - Self::Index::try_from(bit_pos).unwrap()) * tick_spacing;
             Ok((next, initialized))
         } else {
+            // start from the word of the next tick, since the current tick state doesn't matter
+            let compressed = compressed + Self::Index::ONE;
             let (word_pos, bit_pos) = compressed.position();
             // all the 1s at or to the left of the `bit_pos`
             let mask = U256::ZERO - (uint!(1_U256) << bit_pos);


### PR DESCRIPTION
Adjusted the tick map logic to start from the next word when the current tick state is irrelevant. Also updated related tests and documentation to reflect these changes. Updated version numbers in Cargo.toml and README.md to 2.1.1.

Closes #93.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated SDK version to 2.1.1, reflecting improvements and enhancements.
  
- **Bug Fixes**
	- Enhanced testing logic for the `EphemeralTickMapDataProvider` to ensure accurate tick retrieval and initialization status.

- **Documentation**
	- Updated version number in the README for the Uniswap V3 SDK to 2.1.1 in the Getting Started section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->