### PR TITLE
refactor: add `TickListError` and refactor tick list handling methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "2.1.1", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "2.2.0", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/src/entities/position.rs
+++ b/src/entities/position.rs
@@ -125,7 +125,6 @@ impl<TP: TickDataProvider> Position<TP> {
                 )?
                 .to_big_int(),
             )
-            .map_err(Error::Core)
         } else if self.pool.tick_current < self.tick_upper {
             CurrencyAmount::from_raw_amount(
                 self.pool.token0.clone(),
@@ -137,11 +136,10 @@ impl<TP: TickDataProvider> Position<TP> {
                 )?
                 .to_big_int(),
             )
-            .map_err(Error::Core)
         } else {
             CurrencyAmount::from_raw_amount(self.pool.token0.clone(), BigInt::zero())
-                .map_err(Error::Core)
         }
+        .map_err(Error::Core)
     }
 
     /// Returns the amount of token0 that this position's liquidity could be burned for at the
@@ -162,7 +160,6 @@ impl<TP: TickDataProvider> Position<TP> {
     pub fn amount1(&self) -> Result<CurrencyAmount<Token>, Error> {
         if self.pool.tick_current < self.tick_lower {
             CurrencyAmount::from_raw_amount(self.pool.token1.clone(), BigInt::zero())
-                .map_err(Error::Core)
         } else if self.pool.tick_current < self.tick_upper {
             CurrencyAmount::from_raw_amount(
                 self.pool.token1.clone(),
@@ -174,7 +171,6 @@ impl<TP: TickDataProvider> Position<TP> {
                 )?
                 .to_big_int(),
             )
-            .map_err(Error::Core)
         } else {
             CurrencyAmount::from_raw_amount(
                 self.pool.token1.clone(),
@@ -186,8 +182,8 @@ impl<TP: TickDataProvider> Position<TP> {
                 )?
                 .to_big_int(),
             )
-            .map_err(Error::Core)
         }
+        .map_err(Error::Core)
     }
 
     /// Returns the amount of token1 that this position's liquidity could be burned for at the
@@ -216,9 +212,8 @@ impl<TP: TickDataProvider> Position<TP> {
     fn ratios_after_slippage(&self, slippage_tolerance: &Percent) -> (U160, U160) {
         let one = Percent::new(1, 1);
         let token0_price = self.pool.token0_price().as_fraction();
-        let price_lower =
-            token0_price.clone() * ((one.clone() - slippage_tolerance.clone()).as_fraction());
-        let price_upper = token0_price * ((one + slippage_tolerance.clone()).as_fraction());
+        let price_lower = (one.clone() - slippage_tolerance).as_fraction() * &token0_price;
+        let price_upper = token0_price * ((one + slippage_tolerance).as_fraction());
 
         let mut sqrt_ratio_x96_lower =
             encode_sqrt_ratio_x96(price_lower.numerator, price_lower.denominator);

--- a/src/entities/tick_list_data_provider.rs
+++ b/src/entities/tick_list_data_provider.rs
@@ -39,9 +39,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "NOT_CONTAINED")]
+    #[cfg(not(feature = "extensions"))]
     fn throws_if_tick_not_in_list() {
-        PROVIDER.get_tick(0).unwrap();
+        assert_eq!(
+            PROVIDER.get_tick(0).unwrap_err(),
+            TickListError::NotContained.into()
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,4 +67,18 @@ pub enum Error {
     #[cfg(feature = "extensions")]
     #[cfg_attr(feature = "std", error("{0}"))]
     LensError(#[cfg_attr(not(feature = "std"), from)] LensError),
+
+    #[cfg_attr(feature = "std", error("{0}"))]
+    TickListError(#[cfg_attr(not(feature = "std"), from)] TickListError),
+}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+#[cfg_attr(feature = "std", derive(thiserror::Error))]
+pub enum TickListError {
+    #[cfg_attr(feature = "std", error("Below smallest tick"))]
+    BelowSmallest,
+    #[cfg_attr(feature = "std", error("At or above largest tick"))]
+    AtOrAboveLargest,
+    #[cfg_attr(feature = "std", error("Not contained in tick list"))]
+    NotContained,
 }

--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -176,30 +176,34 @@ mod tests {
     };
     const TICKS: [Tick; 3] = [LOW_TICK, MID_TICK, HIGH_TICK];
 
+    mod validate {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "ZERO_NET")]
+        fn test_errors_for_incomplete_lists() {
+            [LOW_TICK].validate_list(1);
+        }
+
+        #[test]
+        #[should_panic(expected = "SORTED")]
+        fn test_errors_for_unsorted_lists() {
+            [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1);
+        }
+
+        #[test]
+        #[should_panic(expected = "TICK_SPACING")]
+        fn test_errors_if_ticks_are_not_on_multiples_of_tick_spacing() {
+            [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1337);
+        }
+    }
+
     #[test]
-    fn test_impl_for_vec() {
+    fn test_binary_search_by_tick() {
         assert_eq!(TICKS.binary_search_by_tick(-1).unwrap(), 0);
         assert_eq!(TICKS.binary_search_by_tick(0).unwrap(), 1);
         assert_eq!(TICKS.binary_search_by_tick(1).unwrap(), 1);
         assert_eq!(TICKS.binary_search_by_tick(MAX_TICK).unwrap(), 2);
-    }
-
-    #[test]
-    #[should_panic(expected = "ZERO_NET")]
-    fn test_validate_list_zero_net() {
-        [LOW_TICK].validate_list(1);
-    }
-
-    #[test]
-    #[should_panic(expected = "SORTED")]
-    fn test_validate_list_unsorted() {
-        [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1);
-    }
-
-    #[test]
-    #[should_panic(expected = "TICK_SPACING")]
-    fn test_validate_list_tick_spacing() {
-        [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1337);
     }
 
     #[test]
@@ -214,193 +218,167 @@ mod tests {
         assert!(TICKS.is_at_or_above_largest(MAX_TICK - 1));
     }
 
-    #[test]
-    #[cfg(not(feature = "extensions"))]
-    fn test_next_initialized_tick_low_lte_true() {
-        assert_eq!(
-            TICKS.next_initialized_tick(MIN_TICK, true).unwrap_err(),
-            TickListError::BelowSmallest.into()
-        );
+    mod next_initialized_tick {
+        use super::*;
+
+        #[test]
+        #[cfg(not(feature = "extensions"))]
+        fn test_low_lte_true() {
+            assert_eq!(
+                TICKS.next_initialized_tick(MIN_TICK, true).unwrap_err(),
+                TickListError::BelowSmallest.into()
+            );
+        }
+
+        #[test]
+        fn test_low_lte_true_2() {
+            assert_eq!(
+                TICKS.next_initialized_tick(MIN_TICK + 1, true).unwrap(),
+                &LOW_TICK
+            );
+            assert_eq!(
+                TICKS.next_initialized_tick(MIN_TICK + 2, true).unwrap(),
+                &LOW_TICK
+            );
+        }
+
+        #[test]
+        fn test_low_lte_false() {
+            assert_eq!(
+                TICKS.next_initialized_tick(MIN_TICK, false).unwrap(),
+                &LOW_TICK
+            );
+            assert_eq!(
+                TICKS.next_initialized_tick(MIN_TICK + 1, false).unwrap(),
+                &MID_TICK
+            );
+        }
+
+        #[test]
+        fn test_mid_lte_true() {
+            assert_eq!(TICKS.next_initialized_tick(0, true).unwrap(), &MID_TICK);
+            assert_eq!(TICKS.next_initialized_tick(1, true).unwrap(), &MID_TICK);
+        }
+
+        #[test]
+        fn test_mid_lte_false() {
+            assert_eq!(TICKS.next_initialized_tick(-1, false).unwrap(), &MID_TICK);
+            assert_eq!(TICKS.next_initialized_tick(1, false).unwrap(), &HIGH_TICK);
+        }
+
+        #[test]
+        fn test_high_lte_true() {
+            assert_eq!(
+                TICKS.next_initialized_tick(MAX_TICK - 1, true).unwrap(),
+                &HIGH_TICK
+            );
+            assert_eq!(
+                TICKS.next_initialized_tick(MAX_TICK, true).unwrap(),
+                &HIGH_TICK
+            );
+        }
+
+        #[test]
+        #[cfg(not(feature = "extensions"))]
+        fn test_high_lte_false() {
+            assert_eq!(
+                TICKS
+                    .next_initialized_tick(MAX_TICK - 1, false)
+                    .unwrap_err(),
+                TickListError::AtOrAboveLargest.into()
+            );
+        }
+
+        #[test]
+        fn test_high_lte_false_2() {
+            assert_eq!(
+                TICKS.next_initialized_tick(MAX_TICK - 2, false).unwrap(),
+                &HIGH_TICK
+            );
+            assert_eq!(
+                TICKS.next_initialized_tick(MAX_TICK - 3, false).unwrap(),
+                &HIGH_TICK
+            );
+        }
     }
 
-    #[test]
-    fn test_next_initialized_tick_low_lte_true_2() {
-        assert_eq!(
-            TICKS.next_initialized_tick(MIN_TICK + 1, true).unwrap(),
-            &LOW_TICK
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick(MIN_TICK + 2, true).unwrap(),
-            &LOW_TICK
-        );
-    }
+    mod next_initialized_tick_within_one_word {
+        use super::*;
 
-    #[test]
-    fn test_next_initialized_tick_low_lte_false() {
-        assert_eq!(
-            TICKS.next_initialized_tick(MIN_TICK, false).unwrap(),
-            &LOW_TICK
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick(MIN_TICK + 1, false).unwrap(),
-            &MID_TICK
-        );
-    }
+        #[test]
+        fn test_words_around_0_lte_true() {
+            macro_rules! test_for_true {
+                ($tick:expr, $next:expr, $initialized:expr) => {
+                    assert_eq!(
+                        TICKS
+                            .next_initialized_tick_within_one_word($tick, true, 1)
+                            .unwrap(),
+                        ($next, $initialized)
+                    );
+                };
+            }
 
-    #[test]
-    fn test_next_initialized_tick_mid_lte_true() {
-        assert_eq!(TICKS.next_initialized_tick(0, true).unwrap(), &MID_TICK);
-        assert_eq!(TICKS.next_initialized_tick(1, true).unwrap(), &MID_TICK);
-    }
+            test_for_true!(-257, -512, false);
+            test_for_true!(-256, -256, false);
+            test_for_true!(-1, -256, false);
+            test_for_true!(0, 0, true);
+            test_for_true!(1, 0, true);
+            test_for_true!(255, 0, true);
+            test_for_true!(256, 256, false);
+            test_for_true!(257, 256, false);
+        }
 
-    #[test]
-    fn test_next_initialized_tick_mid_lte_false() {
-        assert_eq!(TICKS.next_initialized_tick(-1, false).unwrap(), &MID_TICK);
-        assert_eq!(TICKS.next_initialized_tick(1, false).unwrap(), &HIGH_TICK);
-    }
+        #[test]
+        fn test_words_around_0_lte_false() {
+            macro_rules! test_for_false {
+                ($tick:expr, $next:expr, $initialized:expr) => {
+                    assert_eq!(
+                        TICKS
+                            .next_initialized_tick_within_one_word($tick, false, 1)
+                            .unwrap(),
+                        ($next, $initialized)
+                    );
+                };
+            }
 
-    #[test]
-    fn test_next_initialized_tick_high_lte_true() {
-        assert_eq!(
-            TICKS.next_initialized_tick(MAX_TICK - 1, true).unwrap(),
-            &HIGH_TICK
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick(MAX_TICK, true).unwrap(),
-            &HIGH_TICK
-        );
-    }
+            test_for_false!(-258, -257, false);
+            test_for_false!(-257, -1, false);
+            test_for_false!(-256, -1, false);
+            test_for_false!(-2, -1, false);
+            test_for_false!(-1, 0, true);
+            test_for_false!(0, 255, false);
+            test_for_false!(1, 255, false);
+            test_for_false!(254, 255, false);
+            test_for_false!(255, 511, false);
+            test_for_false!(256, 511, false);
+        }
 
-    #[test]
-    #[cfg(not(feature = "extensions"))]
-    fn test_next_initialized_tick_high_lte_false() {
-        assert_eq!(
-            TICKS
-                .next_initialized_tick(MAX_TICK - 1, false)
-                .unwrap_err(),
-            TickListError::AtOrAboveLargest.into()
-        );
-    }
-
-    #[test]
-    fn test_next_initialized_tick_high_lte_false_2() {
-        assert_eq!(
-            TICKS.next_initialized_tick(MAX_TICK - 2, false).unwrap(),
-            &HIGH_TICK
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick(MAX_TICK - 3, false).unwrap(),
-            &HIGH_TICK
-        );
-    }
-
-    #[test]
-    fn test_next_initialized_tick_within_one_word_lte_true() -> Result<(), Error> {
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-257, true, 1)?,
-            (-512, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-256, true, 1)?,
-            (-256, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-1, true, 1)?,
-            (-256, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(0, true, 1)?,
-            (0, true)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(1, true, 1)?,
-            (0, true)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(255, true, 1)?,
-            (0, true)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(256, true, 1)?,
-            (256, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(257, true, 1)?,
-            (256, false)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_next_initialized_tick_within_one_word_lte_false() -> Result<(), Error> {
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-258, false, 1)?,
-            (-257, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-257, false, 1)?,
-            (-1, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-256, false, 1)?,
-            (-1, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-2, false, 1)?,
-            (-1, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(-1, false, 1)?,
-            (0, true)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(0, false, 1)?,
-            (255, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(1, false, 1)?,
-            (255, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(254, false, 1)?,
-            (255, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(255, false, 1)?,
-            (511, false)
-        );
-        assert_eq!(
-            TICKS.next_initialized_tick_within_one_word(256, false, 1)?,
-            (511, false)
-        );
-        Ok(())
-    }
-
-    #[test]
-    fn test_next_initialized_tick_within_one_word_tick_spacing_gt_1() {
-        let ticks = [
-            Tick {
-                index: 0,
-                liquidity_net: 0,
-                liquidity_gross: 0,
-            },
-            Tick {
-                index: 511,
-                liquidity_net: 0,
-                liquidity_gross: 0,
-            },
-        ];
-        assert_eq!(
-            ticks
-                .next_initialized_tick_within_one_word(0, false, 1)
-                .unwrap(),
-            (255, false)
-        );
-        assert_eq!(
-            ticks
-                .next_initialized_tick_within_one_word(0, false, 2)
-                .unwrap(),
-            (510, false)
-        );
+        #[test]
+        fn test_performs_correctly_with_tick_spacing_gt_1() {
+            let ticks = [
+                Tick {
+                    index: 0,
+                    liquidity_net: 0,
+                    liquidity_gross: 0,
+                },
+                Tick {
+                    index: 511,
+                    liquidity_net: 0,
+                    liquidity_gross: 0,
+                },
+            ];
+            assert_eq!(
+                ticks
+                    .next_initialized_tick_within_one_word(0, false, 1)
+                    .unwrap(),
+                (255, false)
+            );
+            assert_eq!(
+                ticks
+                    .next_initialized_tick_within_one_word(0, false, 2)
+                    .unwrap(),
+                (510, false)
+            );
+        }
     }
 }


### PR DESCRIPTION
Introduce a new `TickListError` enum to handle various tick list errors. Methods within `TickList` and `TickDataProvider` are refactored to utilize the new error type, ensuring better error handling and more robust code. Tests are updated to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated package version to 2.2.0.
	- Introduced caching methods for token amounts in liquidity positions.
	- Enhanced error handling for tick list operations.

- **Bug Fixes**
	- Improved error handling in tick list methods to prevent panics and ensure proper error reporting.

- **Documentation**
	- Updated README with enhanced details about SDK features and performance benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->