### PR TITLE
refactor: add derive `Debug` to `Position` and `Pool`

### DIFF
--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -1,13 +1,12 @@
 use crate::prelude::{Error, *};
 use alloy_primitives::{ChainId, B256, I256, U160};
-use core::fmt;
 use once_cell::sync::Lazy;
 use uniswap_sdk_core::prelude::*;
 
 static _Q192: Lazy<BigUint> = Lazy::new(|| Q192.to_big_uint());
 
 /// Represents a V3 pool
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Pool<TP = NoTickDataProvider>
 where
     TP: TickDataProvider,
@@ -19,23 +18,6 @@ where
     pub liquidity: u128,
     pub tick_current: TP::Index,
     pub tick_data_provider: TP,
-}
-
-impl<TP> fmt::Debug for Pool<TP>
-where
-    TP: TickDataProvider<Index: fmt::Debug>,
-{
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Pool")
-            .field("token0", &self.token0)
-            .field("token1", &self.token1)
-            .field("fee", &self.fee)
-            .field("sqrt_ratio_x96", &self.sqrt_ratio_x96)
-            .field("liquidity", &self.liquidity)
-            .field("tick_current", &self.tick_current)
-            .finish()
-    }
 }
 
 impl<TP> PartialEq for Pool<TP>

--- a/src/entities/position.rs
+++ b/src/entities/position.rs
@@ -1,10 +1,9 @@
 use crate::prelude::{Error, *};
 use alloy_primitives::{U160, U256};
-use core::fmt;
 use uniswap_sdk_core::prelude::*;
 
 /// Represents a position on a Uniswap V3 Pool
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Position<TP = NoTickDataProvider>
 where
     TP: TickDataProvider,
@@ -18,19 +17,10 @@ where
     _mint_amounts: Option<MintAmounts>,
 }
 
-impl<TP> fmt::Debug for Position<TP>
-where
-    TP: TickDataProvider<Index: fmt::Debug>,
-{
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Position")
-            .field("pool", &self.pool)
-            .field("tick_lower", &self.tick_lower)
-            .field("tick_upper", &self.tick_upper)
-            .field("liquidity", &self.liquidity)
-            .finish()
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MintAmounts {
+    pub amount0: U256,
+    pub amount1: U256,
 }
 
 impl<TP> PartialEq for Position<TP>
@@ -44,12 +34,6 @@ where
             && self.tick_upper == other.tick_upper
             && self.liquidity == other.liquidity
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MintAmounts {
-    pub amount0: U256,
-    pub amount1: U256,
 }
 
 impl<TP: TickDataProvider> Position<TP> {


### PR DESCRIPTION
This commit adds the `Debug` trait to `Position` and `Pool` structs directly via the `#[derive(Debug)]` attribute. This change simplifies the code by removing manual implementations of the `fmt::Debug` trait for these structs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced debugging capabilities for the `Pool` and `Position` structs through the addition of the `Debug` trait.
	- Improved representation of `MintAmounts` struct for better debugging and comparison.

- **Bug Fixes**
	- Removed outdated custom implementations of the `Debug` trait for both `Pool` and `Position`, ensuring consistent and informative output.

- **Documentation**
	- Updated struct signatures to reflect new trait implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->