### PR TITLE
feat: refactor and add `Multicall` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.2.0"
+version = "2.3.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ alloy-signer-local = "0.5"
 criterion = "0.5.1"
 dotenv = "0.15.0"
 tokio = { version = "1.40", features = ["full"] }
-uniswap_v3_math = "0.5.1"
+uniswap_v3_math = "0.5.2"
 
 [[bench]]
 name = "bit_math"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "2.2.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "2.3.0", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -269,7 +269,9 @@ impl<TP: Clone + TickDataProvider> Pool<TP> {
         input_amount: &CurrencyAmount<impl BaseCurrency>,
         sqrt_price_limit_x96: Option<U160>,
     ) -> Result<(CurrencyAmount<&Token>, Self), Error> {
-        assert!(self.involves_token(&input_amount.currency), "TOKEN");
+        if !self.involves_token(&input_amount.currency) {
+            return Err(Error::InvalidToken);
+        }
 
         let zero_for_one = input_amount.currency.equals(&self.token0);
 
@@ -324,7 +326,9 @@ impl<TP: Clone + TickDataProvider> Pool<TP> {
         output_amount: &CurrencyAmount<impl BaseCurrency>,
         sqrt_price_limit_x96: Option<U160>,
     ) -> Result<(CurrencyAmount<&Token>, Self), Error> {
-        assert!(self.involves_token(&output_amount.currency), "TOKEN");
+        if !self.involves_token(&output_amount.currency) {
+            return Err(Error::InvalidToken);
+        }
 
         let zero_for_one = output_amount.currency.equals(&self.token1);
 


### PR DESCRIPTION
Refactor `encode_multicall` and `decode_multicall` to be more generic and implement the `Multicall` trait for various types. This improves the flexibility and reusability of multicall encoding and decoding operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated version number for the Uniswap V3 SDK to 2.3.0, signaling a new release.
	- Enhanced flexibility in encoding and decoding functionalities to support various byte-like inputs.
	- Improved error handling in the Pool struct methods for better control flow and graceful failure.

- **Documentation**
	- Updated README to reflect the new version number in examples, maintaining existing content structure.

- **Bug Fixes**
	- Adjusted test cases for compatibility with new encoding and decoding method signatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->