### PR TITLE
perf: refactor `Trade` methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ uniswap-sdk-core = "3.0.0"
 [features]
 default = []
 extensions = ["alloy", "anyhow", "base64", "regex", "serde_json", "uniswap-lens"]
-std = ["alloy?/std", "thiserror", "uniswap-sdk-core/std", "uniswap-lens?/std", ]
+std = ["alloy?/std", "thiserror", "uniswap-sdk-core/std", "uniswap-lens?/std"]
 
 [dev-dependencies]
 alloy-signer = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.4.0"
+version = "2.4.1"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -34,8 +34,8 @@ uniswap-sdk-core = "3.0.0"
 
 [features]
 default = []
-extensions = ["uniswap-lens/std", "alloy", "anyhow", "base64", "regex", "serde_json"]
-std = ["thiserror", "uniswap-sdk-core/std"]
+extensions = ["alloy", "anyhow", "base64", "regex", "serde_json", "uniswap-lens"]
+std = ["alloy?/std", "thiserror", "uniswap-sdk-core/std", "uniswap-lens?/std", ]
 
 [dev-dependencies]
 alloy-signer = "0.5"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types)]
-
 use alloy_primitives::{
     address,
     aliases::{I24, U24},
@@ -13,6 +11,8 @@ pub const POOL_INIT_CODE_HASH: B256 =
 
 /// The default factory enabled fee amounts, denominated in hundredths of bips.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u32)]
+#[allow(non_camel_case_types)]
 pub enum FeeAmount {
     LOWEST = 100,
     LOW_200 = 200,

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -665,8 +665,7 @@ where
             None => currency_amount_in.wrapped()?,
         };
         let token_out = currency_out.wrapped();
-        for i in 0..pools.len() {
-            let pool = &pools[i];
+        for (i, pool) in pools.iter().enumerate() {
             // pool irrelevant
             if !pool.involves_token(&amount_in.currency) {
                 continue;
@@ -691,9 +690,10 @@ where
                 )?;
                 sorted_insert(best_trades, trade, max_num_results, trade_comparator)?;
             } else if max_hops > 1 && pools.len() > 1 {
-                let pools_excluding_this_pool = pools[..i]
+                let pools_excluding_this_pool = pools
                     .iter()
-                    .chain(pools[i + 1..].iter())
+                    .take(i)
+                    .chain(pools.iter().skip(i + 1))
                     .cloned()
                     .collect();
                 // otherwise, consider all the other paths that lead from this token as long as we
@@ -758,8 +758,7 @@ where
             None => currency_amount_out.wrapped()?,
         };
         let token_in = currency_in.wrapped();
-        for i in 0..pools.len() {
-            let pool = &pools[i];
+        for (i, pool) in pools.iter().enumerate() {
             // pool irrelevant
             if !pool.involves_token(&amount_out.currency) {
                 continue;
@@ -784,9 +783,10 @@ where
                 )?;
                 sorted_insert(best_trades, trade, max_num_results, trade_comparator)?;
             } else if max_hops > 1 && pools.len() > 1 {
-                let pools_excluding_this_pool = pools[..i]
+                let pools_excluding_this_pool = pools
                     .iter()
-                    .chain(pools[i + 1..].iter())
+                    .take(i)
+                    .chain(pools.iter().skip(i + 1))
                     .cloned()
                     .collect();
                 // otherwise, consider all the other paths that arrive at this token as long as we


### PR DESCRIPTION
Refactored `input_amount` and `output_amount` methods to use `Fraction` for cleaner and more efficient code. Improved heuristic algorithm in functions handling pool exclusions during trade computations. Added `#[repr(u32)]` and `#[allow(non_camel_case_types)]` attributes to `FeeAmount` enum and updated crate version to `2.4.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 2.4.1, enhancing dependency management.
	- Improved precision in trade calculations for input and output amounts.
- **Bug Fixes**
	- Enhanced clarity in trading logic by refining the iteration method for pool selection.
- **Refactor**
	- Structural changes to the `FeeAmount` enum for better representation.
	- Refactored methods in the `Trade` struct to improve calculation accuracy and control flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->