### PR TITLE
fix: change rounding parameters to use defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rustc-hash = "2.0"
 serde_json = { version = "1.0", optional = true }
 thiserror = { version = "2", default-features = false }
 uniswap-lens = { version = "0.7", optional = true }
-uniswap-sdk-core = "3.1.0"
+uniswap-sdk-core = "3.2.0"
 
 [features]
 default = []

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -474,7 +474,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             pool.token0_price()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "1.01"
         );
@@ -488,7 +488,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             pool.token0_price()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "1.01"
         );
@@ -506,7 +506,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             pool.token1_price()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "0.9901"
         );
@@ -520,7 +520,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             pool.token1_price()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "0.9901"
         );

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -472,12 +472,7 @@ mod tests {
             0,
         )
         .unwrap();
-        assert_eq!(
-            pool.token0_price()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
-                .unwrap(),
-            "1.01"
-        );
+        assert_eq!(pool.token0_price().to_significant(5, None).unwrap(), "1.01");
         let pool = Pool::new(
             DAI.clone(),
             USDC.clone(),
@@ -486,12 +481,7 @@ mod tests {
             0,
         )
         .unwrap();
-        assert_eq!(
-            pool.token0_price()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
-                .unwrap(),
-            "1.01"
-        );
+        assert_eq!(pool.token0_price().to_significant(5, None).unwrap(), "1.01");
     }
 
     #[test]
@@ -505,9 +495,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            pool.token1_price()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
-                .unwrap(),
+            pool.token1_price().to_significant(5, None).unwrap(),
             "0.9901"
         );
         let pool = Pool::new(
@@ -519,9 +507,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            pool.token1_price()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
-                .unwrap(),
+            pool.token1_price().to_significant(5, None).unwrap(),
             "0.9901"
         );
     }

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -227,7 +227,7 @@ mod tests {
         fn correct_for_0_1() {
             let route = Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), TOKEN1.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.2000");
+            assert_eq!(price.to_fixed(4, None), "0.2000");
             assert_eq!(price.base_currency, *TOKEN0);
             assert_eq!(price.quote_currency, *TOKEN1);
         }
@@ -243,7 +243,7 @@ mod tests {
         fn correct_for_1_0() {
             let route = Route::new(vec![POOL_0_1.clone()], TOKEN1.clone(), TOKEN0.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "5.0000");
+            assert_eq!(price.to_fixed(4, None), "5.0000");
             assert_eq!(price.base_currency, *TOKEN1);
             assert_eq!(price.quote_currency, *TOKEN0);
         }
@@ -256,7 +256,7 @@ mod tests {
                 TOKEN2.clone(),
             );
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.1000");
+            assert_eq!(price.to_fixed(4, None), "0.1000");
             assert_eq!(price.base_currency, *TOKEN0);
             assert_eq!(price.quote_currency, *TOKEN2);
         }
@@ -269,7 +269,7 @@ mod tests {
                 TOKEN0.clone(),
             );
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "10.0000");
+            assert_eq!(price.to_fixed(4, None), "10.0000");
             assert_eq!(price.base_currency, *TOKEN2);
             assert_eq!(price.quote_currency, *TOKEN0);
         }
@@ -278,7 +278,7 @@ mod tests {
         fn correct_for_ether_0() {
             let route = Route::new(vec![POOL_0_WETH.clone()], ETHER.clone(), TOKEN0.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.3333");
+            assert_eq!(price.to_fixed(4, None), "0.3333");
             assert_eq!(price.base_currency, *ETHER);
             assert_eq!(price.quote_currency, *TOKEN0);
         }
@@ -287,7 +287,7 @@ mod tests {
         fn correct_for_1_weth() {
             let route = Route::new(vec![POOL_1_WETH.clone()], TOKEN1.clone(), WETH.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.1429");
+            assert_eq!(price.to_fixed(4, None), "0.1429");
             assert_eq!(price.base_currency, *TOKEN1);
             assert_eq!(price.quote_currency, *WETH);
         }
@@ -302,7 +302,7 @@ mod tests {
             let price = route.mid_price().unwrap();
             assert_eq!(
                 price
-                    .to_significant(4, Some(Rounding::RoundHalfUp))
+                    .to_significant(4, None)
                     .unwrap(),
                 "0.009524"
             );
@@ -320,7 +320,7 @@ mod tests {
             let price = route.mid_price().unwrap();
             assert_eq!(
                 price
-                    .to_significant(4, Some(Rounding::RoundHalfUp))
+                    .to_significant(4, None)
                     .unwrap(),
                 "0.009524"
             );

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -300,12 +300,7 @@ mod tests {
                 WETH.clone(),
             );
             let price = route.mid_price().unwrap();
-            assert_eq!(
-                price
-                    .to_significant(4, None)
-                    .unwrap(),
-                "0.009524"
-            );
+            assert_eq!(price.to_significant(4, None).unwrap(), "0.009524");
             assert_eq!(price.base_currency, *ETHER);
             assert_eq!(price.quote_currency, *WETH);
         }
@@ -318,12 +313,7 @@ mod tests {
                 ETHER.clone(),
             );
             let price = route.mid_price().unwrap();
-            assert_eq!(
-                price
-                    .to_significant(4, None)
-                    .unwrap(),
-                "0.009524"
-            );
+            assert_eq!(price.to_significant(4, None).unwrap(), "0.009524");
             assert_eq!(price.base_currency, *WETH);
             assert_eq!(price.quote_currency, *ETHER);
         }

--- a/src/entities/route.rs
+++ b/src/entities/route.rs
@@ -227,7 +227,7 @@ mod tests {
         fn correct_for_0_1() {
             let route = Route::new(vec![POOL_0_1.clone()], TOKEN0.clone(), TOKEN1.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.2000");
+            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.2000");
             assert_eq!(price.base_currency, *TOKEN0);
             assert_eq!(price.quote_currency, *TOKEN1);
         }
@@ -243,7 +243,7 @@ mod tests {
         fn correct_for_1_0() {
             let route = Route::new(vec![POOL_0_1.clone()], TOKEN1.clone(), TOKEN0.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "5.0000");
+            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "5.0000");
             assert_eq!(price.base_currency, *TOKEN1);
             assert_eq!(price.quote_currency, *TOKEN0);
         }
@@ -256,7 +256,7 @@ mod tests {
                 TOKEN2.clone(),
             );
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.1000");
+            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.1000");
             assert_eq!(price.base_currency, *TOKEN0);
             assert_eq!(price.quote_currency, *TOKEN2);
         }
@@ -269,7 +269,7 @@ mod tests {
                 TOKEN0.clone(),
             );
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "10.0000");
+            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "10.0000");
             assert_eq!(price.base_currency, *TOKEN2);
             assert_eq!(price.quote_currency, *TOKEN0);
         }
@@ -278,7 +278,7 @@ mod tests {
         fn correct_for_ether_0() {
             let route = Route::new(vec![POOL_0_WETH.clone()], ETHER.clone(), TOKEN0.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.3333");
+            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.3333");
             assert_eq!(price.base_currency, *ETHER);
             assert_eq!(price.quote_currency, *TOKEN0);
         }
@@ -287,7 +287,7 @@ mod tests {
         fn correct_for_1_weth() {
             let route = Route::new(vec![POOL_1_WETH.clone()], TOKEN1.clone(), WETH.clone());
             let price = route.mid_price().unwrap();
-            assert_eq!(price.to_fixed(4, Rounding::RoundHalfUp), "0.1429");
+            assert_eq!(price.to_fixed(4, Some(Rounding::RoundHalfUp)), "0.1429");
             assert_eq!(price.base_currency, *TOKEN1);
             assert_eq!(price.quote_currency, *WETH);
         }
@@ -301,7 +301,9 @@ mod tests {
             );
             let price = route.mid_price().unwrap();
             assert_eq!(
-                price.to_significant(4, Rounding::RoundHalfUp).unwrap(),
+                price
+                    .to_significant(4, Some(Rounding::RoundHalfUp))
+                    .unwrap(),
                 "0.009524"
             );
             assert_eq!(price.base_currency, *ETHER);
@@ -317,7 +319,9 @@ mod tests {
             );
             let price = route.mid_price().unwrap();
             assert_eq!(
-                price.to_significant(4, Rounding::RoundHalfUp).unwrap(),
+                price
+                    .to_significant(4, Some(Rounding::RoundHalfUp))
+                    .unwrap(),
                 "0.009524"
             );
             assert_eq!(price.base_currency, *WETH);

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -1567,7 +1567,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Some(Rounding::RoundHalfUp))
+                        .to_significant(3, None)
                         .unwrap(),
                     "17.2"
                 );
@@ -1589,7 +1589,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Some(Rounding::RoundHalfUp))
+                        .to_significant(3, None)
                         .unwrap(),
                     "19.8"
                 );
@@ -1663,7 +1663,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Some(Rounding::RoundHalfUp))
+                        .to_significant(3, None)
                         .unwrap(),
                     "23.1"
                 );
@@ -1685,7 +1685,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Some(Rounding::RoundHalfUp))
+                        .to_significant(3, None)
                         .unwrap(),
                     "25.5"
                 );

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -1567,7 +1567,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Rounding::RoundHalfUp)
+                        .to_significant(3, Some(Rounding::RoundHalfUp))
                         .unwrap(),
                     "17.2"
                 );
@@ -1589,7 +1589,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Rounding::RoundHalfUp)
+                        .to_significant(3, Some(Rounding::RoundHalfUp))
                         .unwrap(),
                     "19.8"
                 );
@@ -1663,7 +1663,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Rounding::RoundHalfUp)
+                        .to_significant(3, Some(Rounding::RoundHalfUp))
                         .unwrap(),
                     "23.1"
                 );
@@ -1685,7 +1685,7 @@ mod tests {
                         .clone()
                         .price_impact()
                         .unwrap()
-                        .to_significant(3, Rounding::RoundHalfUp)
+                        .to_significant(3, Some(Rounding::RoundHalfUp))
                         .unwrap(),
                     "25.5"
                 );

--- a/src/utils/price_tick_conversions.rs
+++ b/src/utils/price_tick_conversions.rs
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN1.clone(), TOKEN0.clone(), -I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
+                .to_significant(5, None)
                 .unwrap(),
             "1800"
         );
@@ -114,7 +114,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN0.clone(), TOKEN1.clone(), -I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
+                .to_significant(5, None)
                 .unwrap(),
             "0.00055556"
         );
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN0.clone(), TOKEN1.clone(), I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
+                .to_significant(5, None)
                 .unwrap(),
             "1800"
         );
@@ -136,7 +136,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN1.clone(), TOKEN0.clone(), I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Some(Rounding::RoundHalfUp))
+                .to_significant(5, None)
                 .unwrap(),
             "0.00055556"
         );
@@ -151,7 +151,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Some(Rounding::RoundHalfUp))
+            .to_significant(5, None)
             .unwrap(),
             "1.01"
         );
@@ -166,7 +166,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Some(Rounding::RoundHalfUp))
+            .to_significant(5, None)
             .unwrap(),
             "0.99015"
         );
@@ -181,7 +181,7 @@ mod tests {
                 -I24::from_limbs([276423])
             )
             .unwrap()
-            .to_significant(5, Some(Rounding::RoundHalfUp))
+            .to_significant(5, None)
             .unwrap(),
             "0.99015"
         );
@@ -196,7 +196,7 @@ mod tests {
                 -I24::from_limbs([276423])
             )
             .unwrap()
-            .to_significant(5, Some(Rounding::RoundHalfUp))
+            .to_significant(5, None)
             .unwrap(),
             "1.0099"
         );
@@ -211,7 +211,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Some(Rounding::RoundHalfUp))
+            .to_significant(5, None)
             .unwrap(),
             "1.01"
         );
@@ -226,7 +226,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Some(Rounding::RoundHalfUp))
+            .to_significant(5, None)
             .unwrap(),
             "0.99015"
         );

--- a/src/utils/price_tick_conversions.rs
+++ b/src/utils/price_tick_conversions.rs
@@ -103,7 +103,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN1.clone(), TOKEN0.clone(), -I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "1800"
         );
@@ -114,7 +114,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN0.clone(), TOKEN1.clone(), -I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "0.00055556"
         );
@@ -125,7 +125,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN0.clone(), TOKEN1.clone(), I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "1800"
         );
@@ -136,7 +136,7 @@ mod tests {
         assert_eq!(
             tick_to_price(TOKEN1.clone(), TOKEN0.clone(), I24::from_limbs([74959]))
                 .unwrap()
-                .to_significant(5, Rounding::RoundHalfUp)
+                .to_significant(5, Some(Rounding::RoundHalfUp))
                 .unwrap(),
             "0.00055556"
         );
@@ -151,7 +151,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Rounding::RoundHalfUp)
+            .to_significant(5, Some(Rounding::RoundHalfUp))
             .unwrap(),
             "1.01"
         );
@@ -166,7 +166,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Rounding::RoundHalfUp)
+            .to_significant(5, Some(Rounding::RoundHalfUp))
             .unwrap(),
             "0.99015"
         );
@@ -181,7 +181,7 @@ mod tests {
                 -I24::from_limbs([276423])
             )
             .unwrap()
-            .to_significant(5, Rounding::RoundHalfUp)
+            .to_significant(5, Some(Rounding::RoundHalfUp))
             .unwrap(),
             "0.99015"
         );
@@ -196,7 +196,7 @@ mod tests {
                 -I24::from_limbs([276423])
             )
             .unwrap()
-            .to_significant(5, Rounding::RoundHalfUp)
+            .to_significant(5, Some(Rounding::RoundHalfUp))
             .unwrap(),
             "1.0099"
         );
@@ -211,7 +211,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Rounding::RoundHalfUp)
+            .to_significant(5, Some(Rounding::RoundHalfUp))
             .unwrap(),
             "1.01"
         );
@@ -226,7 +226,7 @@ mod tests {
                 -I24::from_limbs([276225])
             )
             .unwrap()
-            .to_significant(5, Rounding::RoundHalfUp)
+            .to_significant(5, Some(Rounding::RoundHalfUp))
             .unwrap(),
             "0.99015"
         );


### PR DESCRIPTION
This commit updates the uniswap-sdk-core-rust from version 3.1.0 to 3.2.0.
https://github.com/malik672/uniswap-sdk-core-rust/pull/89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced `Pool` struct with improved price calculation flexibility and better error handling for token validation.
  - Updated `Trade` struct with new methods for calculating worst execution price and price impact, including slippage checks.
  - Improved `Route` struct with refined mid-price calculations.
  
- **Bug Fixes**
  - Refined error handling in trade execution and price calculations to ensure robustness.

- **Documentation**
  - Minor updates to test cases to reflect changes in method parameters and improve clarity on rounding strategies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->