### PR TITLE
chore: upgrade dependencies and bump version to 2.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.8.0"
+version = "2.9.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -15,7 +15,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.7", optional = true, features = ["contract"] }
+alloy = { version = "0.8", optional = true, features = ["contract"] }
 alloy-primitives = "0.8"
 alloy-sol-types = "0.8"
 anyhow = { version = "1.0", optional = true }
@@ -30,7 +30,7 @@ regex = { version = "1.11", optional = true }
 rustc-hash = "2.0"
 serde_json = { version = "1.0", optional = true }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.8", optional = true }
+uniswap-lens = { version = "0.9.0", optional = true }
 uniswap-sdk-core = "3.2.0"
 
 [features]
@@ -39,8 +39,8 @@ extensions = ["alloy", "anyhow", "base64", "regex", "serde_json", "uniswap-lens"
 std = ["alloy?/std", "thiserror/std", "uniswap-sdk-core/std", "uniswap-lens?/std"]
 
 [dev-dependencies]
-alloy-signer = "0.7"
-alloy-signer-local = "0.7"
+alloy-signer = "0.8"
+alloy-signer-local = "0.8"
 criterion = "0.5.1"
 dotenv = "0.15.0"
 tokio = { version = "1.40", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "2.8.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "2.9.0", features = ["extensions", "std"] }
 ```
 
 ### Usage


### PR DESCRIPTION
Updated various dependencies to their latest versions, including `alloy`, `uniswap-lens`, and `alloy-signer`, to maintain compatibility and improve functionality. Incremented the package version to reflect these updates.