### PR TITLE
feat: add `Eq` and `Default` derivations to structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "2.9.0"
+version = "2.9.1"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -13,6 +13,7 @@ sol! {
             uint160 sqrtPriceX96
         ) external payable returns (address pool);
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct MintParams {
             address token0;
             address token1;
@@ -37,6 +38,7 @@ sol! {
                 uint256 amount1
             );
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct IncreaseLiquidityParams {
             uint256 tokenId;
             uint256 amount0Desired;
@@ -55,6 +57,7 @@ sol! {
                 uint256 amount1
             );
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct DecreaseLiquidityParams {
             uint256 tokenId;
             uint128 liquidity;
@@ -68,6 +71,7 @@ sol! {
             payable
             returns (uint256 amount0, uint256 amount1);
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct CollectParams {
             uint256 tokenId;
             address recipient;
@@ -85,7 +89,7 @@ sol! {
     }
 
     interface IERC721Permit {
-        #[derive(Debug, PartialEq, Eq)]
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct Permit {
             address spender;
             uint256 tokenId;
@@ -109,7 +113,7 @@ sol! {
     }
 
     interface IERC20Permit {
-        #[derive(Debug, PartialEq, Eq)]
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct Permit {
             address owner;
             address spender;
@@ -120,7 +124,7 @@ sol! {
     }
 
     interface IDaiPermit {
-        #[derive(Debug, PartialEq, Eq)]
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct Permit {
             address holder;
             address spender;
@@ -158,6 +162,7 @@ sol! {
     }
 
     interface IUniswapV3Staker {
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct IncentiveKey {
             address rewardToken;
             address pool;
@@ -217,6 +222,7 @@ sol! {
                 uint256 gasEstimate
             );
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct QuoteExactInputSingleParams {
             address tokenIn;
             address tokenOut;
@@ -243,6 +249,7 @@ sol! {
                 uint256 gasEstimate
             );
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct QuoteExactOutputSingleParams {
             address tokenIn;
             address tokenOut;
@@ -262,6 +269,7 @@ sol! {
     }
 
     interface ISwapRouter {
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct ExactInputSingleParams {
             address tokenIn;
             address tokenOut;
@@ -275,6 +283,7 @@ sol! {
 
         function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct ExactInputParams {
             bytes path;
             address recipient;
@@ -285,6 +294,7 @@ sol! {
 
         function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct ExactOutputSingleParams {
             address tokenIn;
             address tokenOut;
@@ -298,6 +308,7 @@ sol! {
 
         function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
 
+        #[derive(Debug, Default, PartialEq, Eq)]
         struct ExactOutputParams {
             bytes path;
             address recipient;

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -17,14 +17,14 @@ pub struct IncreaseSpecificOptions {
     pub token_id: U256,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AddLiquiditySpecificOptions {
     Mint(MintSpecificOptions),
     Increase(IncreaseSpecificOptions),
 }
 
 /// Options for producing the calldata to add liquidity.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddLiquidityOptions {
     /// How much the pool price is allowed to move.
     pub slippage_tolerance: Percent,


### PR DESCRIPTION
This commit ensures key structs implement `Eq` and `Default` for consistency and ease of use. It enhances type capabilities in `nonfungible_position_manager.rs` and `abi.rs`. Additionally, it updates the package version to 2.9.1 in `Cargo.toml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated package version to 2.9.1.
	- Introduced new structures for improved parameterization in liquidity management and token operations.

- **Bug Fixes**
	- Enhanced equality comparison capabilities for various structs and enums.

- **Documentation**
	- Updated documentation to reflect new structures and modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->