### PR TITLE
chore: refactor ABI interfaces and improve example code usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ use uniswap_v3_sdk::prelude::*;
 
 ## Note on `no_std`
 
-By default, this library does not depend on the standard library (`std`). However, the `std` feature can be enabled to
-use `thiserror` for error handling.
+By default, this library does not depend on the standard library (`std`). However, the `std` feature can be enabled.
 
 ## Examples
 

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -11,20 +11,21 @@ use alloy::{
     eips::BlockId,
     providers::{Provider, ProviderBuilder},
     rpc::types::TransactionRequest,
+    transports::http::reqwest::Url,
 };
 use alloy_primitives::{address, ruint::aliases::U256, U160};
-use alloy_sol_types::SolValue;
+use alloy_sol_types::SolCall;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().ok();
-    let rpc_url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
+    let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
     let provider = ProviderBuilder::new().on_http(rpc_url);
     let block_id = BlockId::from(17000000);
     let wbtc = token!(1, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
-    let weth = token!(1, "C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 18, "WETH");
+    let weth = WETH9::on_chain(1).unwrap();
 
     // Create a pool with a tick map data provider
     let pool = Pool::<EphemeralTickMapDataProvider>::from_pool_key_with_tick_data_provider(
@@ -53,15 +54,14 @@ async fn main() {
             use_quoter_v2: false,
         }),
     );
-    let quoter_addr = *QUOTER_ADDRESSES.get(&1).unwrap();
-    let tx = TransactionRequest {
-        to: Some(quoter_addr.into()),
-        input: params.calldata.into(),
-        ..Default::default()
-    };
+    let tx = TransactionRequest::default()
+        .to(*QUOTER_ADDRESSES.get(&1).unwrap())
+        .input(params.calldata.into());
     // Get the output amount from the quoter
     let res = provider.call(&tx).block(block_id).await.unwrap();
-    let amount_out = U256::abi_decode(res.as_ref(), true).unwrap();
+    let amount_out = IQuoter::quoteExactInputSingleCall::abi_decode_returns(res.as_ref(), true)
+        .unwrap()
+        .amountOut;
     println!("Quoter amount out: {}", amount_out);
 
     // Compare local calculation with on-chain quoter to ensure accuracy

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -4,7 +4,9 @@ sol! {
     interface IMulticall {
         function multicall(bytes[] calldata data) external payable returns (bytes[] memory results);
     }
+}
 
+sol! {
     interface INonfungiblePositionManager {
         function createAndInitializePoolIfNecessary(
             address token0,
@@ -187,7 +189,9 @@ sol! {
             uint256 amountRequested
         ) external returns (uint256 reward);
     }
+}
 
+sol! {
     interface IQuoter {
         function quoteExactInput(bytes memory path, uint256 amountIn) external returns (uint256 amountOut);
 
@@ -267,7 +271,9 @@ sol! {
                 uint256 gasEstimate
             );
     }
+}
 
+sol! {
     interface ISwapRouter {
         #[derive(Debug, Default, PartialEq, Eq)]
         struct ExactInputSingleParams {


### PR DESCRIPTION
Refactored ABI definitions for better clarity and separation using `sol!` blocks. Enhanced the example to use `WETH9` and improved transaction building with cleaner syntax. Updated README for concise documentation on `std` feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the README for clearer guidance on enabling the `std` feature.
	- Introduced new interfaces for enhanced token management and swapping: `INonfungiblePositionManager`, `IQuoter`, `IQuoterV2`, and `ISwapRouter`.
- **Improvements**
	- Enhanced type clarity for `rpc_url` and streamlined transaction request construction in the example code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->