### PR TITLE
fix: fix `v` in `self_permit` and add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -67,4 +67,8 @@ required-features = ["extensions"]
 
 [[example]]
 name = "swap_router"
+required-features = ["extensions"]
+
+[[example]]
+name = "self_permit"
 required-features = ["extensions"]

--- a/examples/self_permit.rs
+++ b/examples/self_permit.rs
@@ -1,0 +1,111 @@
+//! Example demonstrating how to sign an ERC20 permit and encode the `selfPermit` call to the
+//! Uniswap V3 NonfungiblePositionManager
+//!
+//! # Prerequisites
+//! - Environment variable MAINNET_RPC_URL must be set
+//! - Requires the "extensions" feature
+//!
+//! # Note
+//! This example uses mainnet block 17000000 for consistent results
+
+use alloy::{
+    eips::BlockId,
+    node_bindings::WEI_IN_ETHER,
+    providers::{ext::AnvilApi, Provider, ProviderBuilder},
+    rpc::types::TransactionRequest,
+    signers::{local::PrivateKeySigner, SignerSync},
+    sol,
+    transports::http::reqwest::Url,
+};
+use alloy_primitives::{address, keccak256, PrimitiveSignature, B256, U256};
+use alloy_sol_types::SolValue;
+use uniswap_sdk_core::{prelude::*, token};
+use uniswap_v3_sdk::prelude::*;
+
+sol! {
+    #[sol(rpc)]
+    interface USDC {
+        function name() returns (string);
+        function version() returns (string);
+        function allowance(address owner, address spender) returns (uint256);
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    dotenv::dotenv().ok();
+    let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
+    let block_id = BlockId::from(17000000);
+
+    // Create an Anvil fork
+    let provider = ProviderBuilder::new()
+        .with_recommended_fillers()
+        .on_anvil_with_config(|anvil| {
+            anvil
+                .fork(rpc_url)
+                .fork_block_number(block_id.as_u64().unwrap())
+        });
+    provider.anvil_auto_impersonate_account(true).await.unwrap();
+
+    let usdc = token!(1, "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6);
+    let npm = *NONFUNGIBLE_POSITION_MANAGER_ADDRESSES.get(&1).unwrap();
+
+    let iusdc = USDC::new(usdc.address(), provider.clone());
+    let name = iusdc.name().call().await.unwrap()._0;
+    let version = iusdc.version().call().await.unwrap()._0;
+
+    // Create a signer and sign a permit
+    let signer = PrivateKeySigner::random();
+    let amount = U256::from_be_slice(keccak256(signer.address().abi_encode()).as_slice());
+    let permit = IERC20Permit::Permit {
+        owner: signer.address(),
+        spender: npm,
+        value: amount,
+        nonce: U256::ZERO,
+        deadline: U256::MAX,
+    };
+    let permit_data = get_erc20_permit_data(permit, name.leak(), version.leak(), usdc.address(), 1);
+    let hash: B256 = permit_data.eip712_signing_hash();
+    let signature: PrimitiveSignature = signer.sign_hash_sync(&hash).unwrap();
+    assert_eq!(
+        signature.recover_address_from_prehash(&hash).unwrap(),
+        signer.address()
+    );
+
+    // Encode the permit calldata
+    let options = PermitOptions::Standard(StandardPermitArguments {
+        signature,
+        amount,
+        deadline: U256::MAX,
+    });
+    let calldata = encode_permit(&usdc, options);
+
+    // Set the signer balance and send the transaction
+    provider
+        .anvil_set_balance(signer.address(), WEI_IN_ETHER)
+        .await
+        .unwrap();
+    let tx = TransactionRequest::default()
+        .from(signer.address())
+        .to(npm)
+        .input(calldata.into());
+    provider
+        .send_transaction(tx)
+        .await
+        .unwrap()
+        .register()
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+
+    // Check the spender allowance
+    let allowance = iusdc
+        .allowance(signer.address(), npm)
+        .call()
+        .await
+        .unwrap()
+        ._0;
+    println!("USDC allowance: {}", allowance);
+    assert_eq!(allowance, amount);
+}

--- a/examples/swap_router.rs
+++ b/examples/swap_router.rs
@@ -20,12 +20,12 @@ use alloy_sol_types::SolCall;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
-sol!(
+sol! {
     #[sol(rpc)]
-    contract IERC20 {
+    interface IERC20 {
         function balanceOf(address target) returns (uint256);
     }
-);
+}
 
 #[tokio::main]
 async fn main() {

--- a/src/self_permit.rs
+++ b/src/self_permit.rs
@@ -1,5 +1,5 @@
 use super::abi::ISelfPermit;
-use alloy_primitives::{Bytes, PrimitiveSignature, U256};
+use alloy_primitives::{Bytes, PrimitiveSignature, B256, U256};
 use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall, SolStruct};
 use uniswap_sdk_core::prelude::*;
 
@@ -7,6 +7,14 @@ use uniswap_sdk_core::prelude::*;
 pub struct ERC20PermitData<P: SolStruct> {
     pub domain: Eip712Domain,
     pub values: P,
+}
+
+impl<P: SolStruct> ERC20PermitData<P> {
+    #[inline]
+    #[must_use]
+    pub fn eip712_signing_hash(&self) -> B256 {
+        self.values.eip712_signing_hash(&self.domain)
+    }
 }
 
 /// Get the EIP-2612 domain and values to sign for an ERC20 permit.
@@ -55,7 +63,7 @@ pub struct ERC20PermitData<P: SolStruct> {
 ///     b256!("ea2aa0a1be11a07ed86d755c93467f4f82362b452371d1ba94d1715123511acb")
 /// );
 ///
-/// let data = get_erc20_permit_data(
+/// let permit_data = get_erc20_permit_data(
 ///     permit,
 ///     "ONE",
 ///     "1",
@@ -64,7 +72,7 @@ pub struct ERC20PermitData<P: SolStruct> {
 /// );
 ///
 /// // Derive the EIP-712 signing hash.
-/// let hash: B256 = data.values.eip712_signing_hash(&data.domain);
+/// let hash: B256 = permit_data.eip712_signing_hash();
 ///
 /// let signature: PrimitiveSignature = signer.sign_hash_sync(&hash).unwrap();
 /// assert_eq!(
@@ -139,13 +147,13 @@ impl AllowedPermitArguments {
 
 #[inline]
 #[must_use]
-pub fn encode_permit(token: &Token, options: PermitOptions) -> Bytes {
+pub fn encode_permit(token: &impl BaseCurrency, options: PermitOptions) -> Bytes {
     match options {
         PermitOptions::Standard(args) => ISelfPermit::selfPermitCall {
             token: token.address(),
             value: args.amount,
             deadline: args.deadline,
-            v: args.signature.v() as u8,
+            v: args.signature.v() as u8 + 27,
             r: args.signature.r().into(),
             s: args.signature.s().into(),
         }
@@ -154,7 +162,7 @@ pub fn encode_permit(token: &Token, options: PermitOptions) -> Bytes {
             token: token.address(),
             nonce: args.nonce,
             expiry: args.expiry,
-            v: args.signature.v() as u8,
+            v: args.signature.v() as u8 + 27,
             r: args.signature.r().into(),
             s: args.signature.s().into(),
         }
@@ -182,8 +190,11 @@ mod tests {
             uint!(123_U256),
             uint!(123_U256),
         );
-        let calldata = encode_permit(&TOKEN, PermitOptions::Standard(standard_permit_options));
-        assert_eq!(calldata, hex!("f3995c670000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002").to_vec());
+        let calldata = encode_permit(
+            &TOKEN.clone(),
+            PermitOptions::Standard(standard_permit_options),
+        );
+        assert_eq!(calldata, hex!("f3995c670000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000001b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002").to_vec());
     }
 
     #[test]
@@ -195,7 +206,10 @@ mod tests {
             uint!(123_U256),
             uint!(123_U256),
         );
-        let calldata = encode_permit(&TOKEN, PermitOptions::Allowed(allowed_permit_options));
-        assert_eq!(calldata, hex!("4659a4940000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002").to_vec());
+        let calldata = encode_permit(
+            &TOKEN.clone(),
+            PermitOptions::Allowed(allowed_permit_options),
+        );
+        assert_eq!(calldata, hex!("4659a4940000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000001b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002").to_vec());
     }
 }


### PR DESCRIPTION
Introduced a new `self_permit` example to demonstrate signing ERC20 permits and encoding `selfPermit` calls for Uniswap V3. Improved encoding logic in `self_permit.rs` by adding EIP-712 signing hash functionality and fixing signature encoding with +27 adjustment. Updated version to 3.1.0 to reflect new functionality.