### PR TITLE
perf: refactor multicall encoding and cleanup redundant clones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "3.1.1"
+version = "3.1.2"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -618,7 +618,7 @@ where
         let mut populated_routes: Vec<Swap<TInput, TOutput, TP>> = Vec::with_capacity(routes.len());
         for (amount, route) in routes {
             let trade = Self::from_route(route, amount, trade_type)?;
-            populated_routes.push(trade.swaps[0].clone());
+            populated_routes.push(trade.swaps.into_iter().next().unwrap());
         }
         Self::new(populated_routes, trade_type)
     }

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -65,7 +65,7 @@ impl Pool {
         let block_id = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
         let pool_contract = get_pool_contract(factory, token_a, token_b, fee, provider.clone());
         let token_a_contract = IERC20Metadata::new(token_a, provider.clone());
-        let token_b_contract = IERC20Metadata::new(token_b, provider.clone());
+        let token_b_contract = IERC20Metadata::new(token_b, provider);
         // TODO: use multicall
         let slot_0 = pool_contract.slot0().block(block_id).call().await?;
         let liquidity = pool_contract.liquidity().block(block_id).call().await?._0;
@@ -171,7 +171,7 @@ impl<I: TickIndex> Pool<EphemeralTickMapDataProvider<I>> {
         .await?;
         let tick_data_provider = EphemeralTickMapDataProvider::new(
             pool.address(None, None),
-            provider.clone(),
+            provider,
             None,
             None,
             block_id,

--- a/src/extensions/state_overrides.rs
+++ b/src/extensions/state_overrides.rs
@@ -1,4 +1,5 @@
 use crate::prelude::Error;
+use alloc::vec::Vec;
 use alloy::{
     eips::eip2930::{AccessList, AccessListItem},
     providers::Provider,

--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -5,11 +5,14 @@ use alloy_sol_types::{Error, SolCall};
 #[inline]
 #[must_use]
 pub fn encode_multicall<B: Into<Bytes>>(data: Vec<B>) -> Bytes {
-    let data: Vec<Bytes> = data.into_iter().map(Into::into).collect();
     if data.len() == 1 {
-        data[0].clone()
+        data.into_iter().next().unwrap().into()
     } else {
-        IMulticall::multicallCall { data }.abi_encode().into()
+        IMulticall::multicallCall {
+            data: data.into_iter().map(Into::into).collect(),
+        }
+        .abi_encode()
+        .into()
     }
 }
 
@@ -91,7 +94,7 @@ mod tests {
                 hex!("ac9650d800000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000800000000000000000000000000000000000000000000000000000000000000020aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000000000000000000000000000000000000000000000000000020bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
             );
 
-            let decoded_calldata: Vec<Vec<u8>> = Multicall::decode_multicall(encoded).unwrap();
+            let decoded_calldata = <Vec<Vec<u8>>>::decode_multicall(encoded).unwrap();
             assert_eq!(decoded_calldata, calldata_list);
         }
     }


### PR DESCRIPTION
Simplifies encoding logic in `encode_multicall` by reducing unnecessary clones and updates type usage for consistency. Improves readability in other modules by removing redundant `.clone()` calls and ensures cleaner ownership handling. Also aligns imports to address missing dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Package Version**
	- Updated Uniswap V3 SDK package version from 3.1.1 to 3.1.2

- **Performance Improvements**
	- Optimized code in multiple modules by removing unnecessary cloning
	- Simplified data handling in encoding and decoding functions

- **Code Enhancements**
	- Refined internal logic in trade, pool, and multicall implementations
	- Added vector import in state overrides module

<!-- end of auto-generated comment: release notes by coderabbit.ai -->