### PR TITLE
refactor!: simplify token amount calculations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -20,7 +20,7 @@ alloy-primitives = "0.8"
 alloy-sol-types = "0.8"
 anyhow = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true }
-bigdecimal = "0.4.5"
+bigdecimal = "0.4.7"
 derive_more = { version = "1.0.0", features = ["deref", "from"] }
 num-bigint = "0.4"
 num-integer = "0.1"
@@ -30,7 +30,7 @@ regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = { version = "2", default-features = false }
 uniswap-lens = { version = "0.10", optional = true }
-uniswap-sdk-core = "3.3.0"
+uniswap-sdk-core = "3.4.0"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Uniswap V3 SDK Rust
 
 [![Rust CI](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/actions/workflows/rust.yml)
-[![docs.rs](https://img.shields.io/docsrs/uniswap-v3-sdk)](https://docs.rs/uniswap-v3-sdk/latest/uniswap_v3_sdk/)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/shuhuiluo/uniswap-v3-sdk-rs?logo=rust&label=CodeRabbit&color=orange)
+[![docs.rs](https://img.shields.io/docsrs/uniswap-v3-sdk)](https://docs.rs/uniswap-v3-sdk/latest)
 [![crates.io](https://img.shields.io/crates/v/uniswap-v3-sdk.svg)](https://crates.io/crates/uniswap-v3-sdk)
 
 A Rust SDK for building applications on top of Uniswap V3. Migration from the
@@ -49,7 +50,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "3.3.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "3.4.0", features = ["extensions", "std"] }
 ```
 
 ### Usage
@@ -115,7 +116,7 @@ To test a specific module, use `cargo test --test <module_name>`.
 
 ### Linting
 
-Linting is done with `clippy` and `rustfmt`. To run the linter, use:
+Linting is done with `clippy` and `rustfmt`. To run the linter, use
 
 ```shell
 cargo clippy --all-targets --all-features -- -D warnings
@@ -124,7 +125,13 @@ cargo fmt --all -- --check
 
 ### Benchmarking
 
-Benchmarking is done with `criterion`. To run the benchmarks, use `cargo bench`.
+Benchmarking is done with `criterion`. To run all the benchmarks, use
+
+```shell
+cargo bench
+```
+
+To run a specific benchmark, use `cargo bench --bench <bench_name>`.
 
 ## License
 

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -41,7 +41,7 @@ async fn main() {
     .unwrap();
     // Get the output amount from the pool
     let amount_in = CurrencyAmount::from_raw_amount(wbtc.clone(), 100000000).unwrap();
-    let (local_amount_out, _pool_after) = pool.get_output_amount(&amount_in, None).unwrap();
+    let local_amount_out = pool.get_output_amount(&amount_in, None).unwrap();
     let local_amount_out = local_amount_out.quotient();
     println!("Local amount out: {}", local_amount_out);
 

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -553,7 +553,7 @@ where
         amount: CurrencyAmount<impl BaseCurrency>,
         trade_type: TradeType,
     ) -> Result<Self, Error> {
-        let mut token_amount: CurrencyAmount<&Token> = amount.wrapped()?;
+        let mut token_amount: CurrencyAmount<Token> = amount.wrapped_owned()?;
         let input_amount: CurrencyAmount<TInput>;
         let output_amount: CurrencyAmount<TOutput>;
         match trade_type {
@@ -563,7 +563,7 @@ where
                     "INPUT"
                 );
                 for pool in &route.pools {
-                    (token_amount, _) = pool.get_output_amount(&token_amount, None)?;
+                    token_amount = pool.get_output_amount(&token_amount, None)?;
                 }
                 output_amount = CurrencyAmount::from_fractional_amount(
                     route.output.clone(),
@@ -582,7 +582,7 @@ where
                     "OUTPUT"
                 );
                 for pool in route.pools.iter().rev() {
-                    (token_amount, _) = pool.get_input_amount(&token_amount, None)?;
+                    token_amount = pool.get_input_amount(&token_amount, None)?;
                 }
                 input_amount = CurrencyAmount::from_fractional_amount(
                     route.input.clone(),
@@ -673,7 +673,7 @@ where
                 continue;
             }
             let amount_out = match pool.get_output_amount(&amount_in, None) {
-                Ok((amount_out, _)) => amount_out,
+                Ok(amount_out) => amount_out,
                 Err(Error::InsufficientLiquidity) => continue,
                 Err(e) => return Err(e),
             };
@@ -711,7 +711,7 @@ where
                         max_hops: Some(max_hops - 1),
                     },
                     next_pools,
-                    Some(amount_out),
+                    Some(amount_out.wrapped()?),
                     best_trades,
                 )?;
             }
@@ -766,7 +766,7 @@ where
                 continue;
             }
             let amount_in = match pool.get_input_amount(&amount_out, None) {
-                Ok((amount_in, _)) => amount_in,
+                Ok(amount_in) => amount_in,
                 Err(Error::InsufficientLiquidity) => continue,
                 Err(e) => return Err(e),
             };
@@ -804,7 +804,7 @@ where
                         max_hops: Some(max_hops - 1),
                     },
                     next_pools,
-                    Some(amount_in),
+                    Some(amount_in.wrapped()?),
                     best_trades,
                 )?;
             }


### PR DESCRIPTION
Refactor `get_output_amount` and `get_input_amount` to remove tuple outputs and streamline logic. Add mutable variants for methods to handle pool state updates effectively. Update dependency versions, bump SDK to 3.4.0, and enhance README with revised usage and benchmark instructions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated Uniswap V3 SDK to version 3.4.0

- **Dependencies**
	- Updated `bigdecimal` dependency to version 0.4.7
	- Updated `uniswap-sdk-core` to version 3.4.0

- **Documentation**
	- Added CodeRabbit Pull Request Reviews badge
	- Updated README with clarified benchmarking instructions
	- Simplified `docs.rs` link

- **Refactor**
	- Modified `Pool` and `Trade` struct methods to improve state management and type handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->