### PR TITLE
refactor(ext): update dependencies and refactor `Transport` to `Network`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -15,7 +15,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.9", optional = true, features = ["contract"] }
+alloy = { version = "0.11", optional = true, features = ["contract"] }
 alloy-primitives = "0.8"
 alloy-sol-types = "0.8"
 anyhow = { version = "1.0", optional = true }
@@ -29,7 +29,7 @@ once_cell = "1.20"
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.10", optional = true }
+uniswap-lens = { version = "0.11", optional = true }
 uniswap-sdk-core = "3.4.0"
 
 [features]
@@ -38,11 +38,11 @@ extensions = ["alloy", "anyhow", "base64", "regex", "serde_json", "uniswap-lens"
 std = ["alloy?/std", "thiserror/std", "uniswap-sdk-core/std", "uniswap-lens?/std"]
 
 [dev-dependencies]
-alloy = { version = "0.9", features = ["provider-anvil-node", "signer-local"] }
+alloy = { version = "0.11", features = ["provider-anvil-node", "signer-local"] }
 criterion = "0.5.1"
 dotenv = "0.15.0"
-tokio = { version = "1.40", features = ["full"] }
-uniswap_v3_math = "0.5.2"
+tokio = { version = "1.43", features = ["full"] }
+uniswap_v3_math = "0.5.3"
 
 [[bench]]
 name = "bit_math"

--- a/examples/self_permit.rs
+++ b/examples/self_permit.rs
@@ -38,13 +38,11 @@ async fn main() {
     let block_id = BlockId::from(17000000);
 
     // Create an Anvil fork
-    let provider = ProviderBuilder::new()
-        .with_recommended_fillers()
-        .on_anvil_with_config(|anvil| {
-            anvil
-                .fork(rpc_url)
-                .fork_block_number(block_id.as_u64().unwrap())
-        });
+    let provider = ProviderBuilder::new().on_anvil_with_config(|anvil| {
+        anvil
+            .fork(rpc_url)
+            .fork_block_number(block_id.as_u64().unwrap())
+    });
     provider.anvil_auto_impersonate_account(true).await.unwrap();
 
     let usdc = token!(1, "A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", 6);

--- a/examples/swap_router.rs
+++ b/examples/swap_router.rs
@@ -65,13 +65,11 @@ async fn main() {
     println!("Quoter amount out: {}", amount_out);
 
     // Create an Anvil fork
-    let provider = ProviderBuilder::new()
-        .with_recommended_fillers()
-        .on_anvil_with_config(|anvil| {
-            anvil
-                .fork(rpc_url)
-                .fork_block_number(block_id.as_u64().unwrap())
-        });
+    let provider = ProviderBuilder::new().on_anvil_with_config(|anvil| {
+        anvil
+            .fork(rpc_url)
+            .fork_block_number(block_id.as_u64().unwrap())
+    });
     let account = provider.get_accounts().await.unwrap()[0];
 
     // Build the swap transaction

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -114,14 +114,14 @@ where
 
     /// Returns the input currency of the swap
     #[inline]
-    pub fn input_currency(&self) -> &TInput {
-        &self.input_amount.currency
+    pub const fn input_currency(&self) -> &TInput {
+        &self.input_amount.meta.currency
     }
 
     /// Returns the output currency of the swap
     #[inline]
-    pub fn output_currency(&self) -> &TOutput {
-        &self.output_amount.currency
+    pub const fn output_currency(&self) -> &TOutput {
+        &self.output_amount.meta.currency
     }
 }
 

--- a/src/extensions/ephemeral_tick_data_provider.rs
+++ b/src/extensions/ephemeral_tick_data_provider.rs
@@ -2,7 +2,7 @@
 //! A data provider that fetches ticks using an [ephemeral contract](https://github.com/Aperture-Finance/Aperture-Lens/blob/904101e4daed59e02fd4b758b98b0749e70b583b/contracts/EphemeralGetPopulatedTicksInRange.sol) in a single `eth_call`.
 
 use crate::prelude::*;
-use alloy::{eips::BlockId, providers::Provider, transports::Transport};
+use alloy::{eips::BlockId, network::Network, providers::Provider};
 use alloy_primitives::{aliases::I24, Address};
 use derive_more::Deref;
 use uniswap_lens::pool_lens;
@@ -21,7 +21,7 @@ pub struct EphemeralTickDataProvider<I = I24> {
 
 impl<I: TickIndex> EphemeralTickDataProvider<I> {
     #[inline]
-    pub async fn new<T, P>(
+    pub async fn new<N, P>(
         pool: Address,
         provider: P,
         tick_lower: Option<I>,
@@ -29,8 +29,8 @@ impl<I: TickIndex> EphemeralTickDataProvider<I> {
         block_id: Option<BlockId>,
     ) -> Result<Self, Error>
     where
-        T: Transport + Clone,
-        P: Provider<T>,
+        N: Network,
+        P: Provider<N>,
     {
         let tick_lower = tick_lower.map_or(MIN_TICK, I::to_i24);
         let tick_upper = tick_upper.map_or(MAX_TICK, I::to_i24);

--- a/src/extensions/ephemeral_tick_map_data_provider.rs
+++ b/src/extensions/ephemeral_tick_map_data_provider.rs
@@ -2,7 +2,7 @@
 //! A data provider that fetches ticks using an [ephemeral contract](https://github.com/Aperture-Finance/Aperture-Lens/blob/904101e4daed59e02fd4b758b98b0749e70b583b/contracts/EphemeralGetPopulatedTicksInRange.sol) in a single `eth_call`.
 
 use crate::prelude::*;
-use alloy::{eips::BlockId, providers::Provider, transports::Transport};
+use alloy::{eips::BlockId, network::Network, providers::Provider};
 use alloy_primitives::{aliases::I24, Address};
 use derive_more::Deref;
 
@@ -20,7 +20,7 @@ pub struct EphemeralTickMapDataProvider<I = I24> {
 
 impl<I: TickIndex> EphemeralTickMapDataProvider<I> {
     #[inline]
-    pub async fn new<T, P>(
+    pub async fn new<N, P>(
         pool: Address,
         provider: P,
         tick_lower: Option<I>,
@@ -28,8 +28,8 @@ impl<I: TickIndex> EphemeralTickMapDataProvider<I> {
         block_id: Option<BlockId>,
     ) -> Result<Self, Error>
     where
-        T: Transport + Clone,
-        P: Provider<T>,
+        N: Network,
+        P: Provider<N>,
     {
         let provider =
             EphemeralTickDataProvider::new(pool, provider, tick_lower, tick_upper, block_id)

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -60,12 +60,12 @@ impl Pool {
     ) -> Result<Self, Error>
     where
         N: Network,
-        P: Provider<N> + Clone,
+        P: Provider<N>,
     {
         let block_id = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
-        let pool_contract = get_pool_contract(factory, token_a, token_b, fee, provider.clone());
-        let token_a_contract = IERC20Metadata::new(token_a, provider.clone());
-        let token_b_contract = IERC20Metadata::new(token_b, provider);
+        let pool_contract = get_pool_contract(factory, token_a, token_b, fee, provider.root());
+        let token_a_contract = IERC20Metadata::new(token_a, provider.root());
+        let token_b_contract = IERC20Metadata::new(token_b, provider.root());
         // TODO: use multicall
         let slot_0 = pool_contract.slot0().block(block_id).call().await?;
         let liquidity = pool_contract.liquidity().block(block_id).call().await?._0;
@@ -157,7 +157,7 @@ impl<I: TickIndex> Pool<EphemeralTickMapDataProvider<I>> {
     ) -> Result<Self, Error>
     where
         N: Network,
-        P: Provider<N> + Clone,
+        P: Provider<N>,
     {
         let pool = Pool::from_pool_key(
             chain_id,
@@ -165,7 +165,7 @@ impl<I: TickIndex> Pool<EphemeralTickMapDataProvider<I>> {
             token_a,
             token_b,
             fee,
-            provider.clone(),
+            provider.root(),
             block_id,
         )
         .await?;

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -6,8 +6,8 @@
 use crate::prelude::{Error, *};
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
+    network::Network,
     providers::Provider,
-    transports::Transport,
 };
 use alloy_primitives::{Address, ChainId, U256};
 use anyhow::Result;
@@ -26,13 +26,13 @@ use uniswap_lens::{
 use uniswap_sdk_core::{prelude::*, token};
 
 #[inline]
-pub const fn get_nonfungible_position_manager_contract<T, P>(
+pub const fn get_nonfungible_position_manager_contract<N, P>(
     nonfungible_position_manager: Address,
     provider: P,
-) -> IUniswapV3NonfungiblePositionManagerInstance<T, P>
+) -> IUniswapV3NonfungiblePositionManagerInstance<(), P, N>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     IUniswapV3NonfungiblePositionManagerInstance::new(nonfungible_position_manager, provider)
 }
@@ -47,7 +47,7 @@ where
 /// * `provider`: The alloy provider
 /// * `block_id`: Optional block number to query
 #[inline]
-pub async fn get_position<T, P>(
+pub async fn get_position<N, P>(
     chain_id: ChainId,
     nonfungible_position_manager: Address,
     token_id: U256,
@@ -55,8 +55,8 @@ pub async fn get_position<T, P>(
     block_id: Option<BlockId>,
 ) -> Result<Position, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T> + Clone,
+    N: Network,
+    P: Provider<N> + Clone,
 {
     let block_id_ = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
     let npm_contract =
@@ -107,7 +107,7 @@ impl Position {
     /// * `provider`: The alloy provider
     /// * `block_id`: Optional block number to query
     #[inline]
-    pub async fn from_token_id<T, P>(
+    pub async fn from_token_id<N, P>(
         chain_id: ChainId,
         nonfungible_position_manager: Address,
         token_id: U256,
@@ -115,8 +115,8 @@ impl Position {
         block_id: Option<BlockId>,
     ) -> Result<Self, Error>
     where
-        T: Transport + Clone,
-        P: Provider<T>,
+        N: Network,
+        P: Provider<N>,
     {
         let EphemeralGetPosition::PositionState {
             position,
@@ -164,7 +164,7 @@ impl<I: TickIndex> Position<EphemeralTickMapDataProvider<I>> {
     ///
     /// [`Position<EphemeralTickMapDataProvider<I>>`]
     #[inline]
-    pub async fn from_token_id_with_tick_data_provider<T, P>(
+    pub async fn from_token_id_with_tick_data_provider<N, P>(
         chain_id: ChainId,
         nonfungible_position_manager: Address,
         token_id: U256,
@@ -172,8 +172,8 @@ impl<I: TickIndex> Position<EphemeralTickMapDataProvider<I>> {
         block_id: Option<BlockId>,
     ) -> Result<Self, Error>
     where
-        T: Transport + Clone,
-        P: Provider<T> + Clone,
+        N: Network,
+        P: Provider<N> + Clone,
     {
         let position = Position::from_token_id(
             chain_id,
@@ -224,15 +224,15 @@ impl<I: TickIndex> Position<EphemeralTickMapDataProvider<I>> {
 /// * `provider`: The alloy provider
 /// * `block_id`: Optional block number to query
 #[inline]
-pub async fn get_all_positions_by_owner<T, P>(
+pub async fn get_all_positions_by_owner<N, P>(
     nonfungible_position_manager: Address,
     owner: Address,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<Vec<EphemeralAllPositionsByOwner::PositionState>, Error>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     position_lens::get_all_positions_by_owner(
         nonfungible_position_manager,
@@ -258,7 +258,7 @@ where
 ///
 /// A tuple of the collectable token amounts.
 #[inline]
-pub async fn get_collectable_token_amounts<T, P>(
+pub async fn get_collectable_token_amounts<N, P>(
     _chain_id: ChainId,
     nonfungible_position_manager: Address,
     token_id: U256,
@@ -266,8 +266,8 @@ pub async fn get_collectable_token_amounts<T, P>(
     block_id: Option<BlockId>,
 ) -> Result<(U256, U256)>
 where
-    T: Transport + Clone,
-    P: Provider<T> + Clone,
+    N: Network,
+    P: Provider<N> + Clone,
 {
     let block_id_ = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
     let npm_contract =
@@ -357,15 +357,15 @@ where
 /// * `provider`: The alloy provider
 /// * `block_id`: Optional block number to query
 #[inline]
-pub async fn get_token_svg<T, P>(
+pub async fn get_token_svg<N, P>(
     nonfungible_position_manager: Address,
     token_id: U256,
     provider: P,
     block_id: Option<BlockId>,
 ) -> Result<String>
 where
-    T: Transport + Clone,
-    P: Provider<T>,
+    N: Network,
+    P: Provider<N>,
 {
     let uri = get_nonfungible_position_manager_contract(nonfungible_position_manager, provider)
         .tokenURI(token_id)

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -56,11 +56,11 @@ pub async fn get_position<N, P>(
 ) -> Result<Position, Error>
 where
     N: Network,
-    P: Provider<N> + Clone,
+    P: Provider<N>,
 {
     let block_id_ = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
     let npm_contract =
-        get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.clone());
+        get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.root());
     // TODO: use multicall
     let factory = npm_contract.factory().block(block_id_).call().await?._0;
     let position = npm_contract
@@ -173,13 +173,13 @@ impl<I: TickIndex> Position<EphemeralTickMapDataProvider<I>> {
     ) -> Result<Self, Error>
     where
         N: Network,
-        P: Provider<N> + Clone,
+        P: Provider<N>,
     {
         let position = Position::from_token_id(
             chain_id,
             nonfungible_position_manager,
             token_id,
-            provider.clone(),
+            provider.root(),
             block_id,
         )
         .await?;
@@ -267,11 +267,11 @@ pub async fn get_collectable_token_amounts<N, P>(
 ) -> Result<(U256, U256)>
 where
     N: Network,
-    P: Provider<N> + Clone,
+    P: Provider<N>,
 {
     let block_id_ = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
     let npm_contract =
-        get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.clone());
+        get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.root());
     // TODO: use multicall
     let factory = npm_contract.factory().block(block_id_).call().await?._0;
     let position = npm_contract

--- a/src/extensions/state_overrides.rs
+++ b/src/extensions/state_overrides.rs
@@ -48,10 +48,20 @@ where
         return Err(Error::InvalidAccessList);
     }
     // get rid of the storage key of implementation address
-    let balance_slots_set =
-        B256HashSet::from_iter(filtered_balance_access_list[0].storage_keys.clone());
-    let allowance_slots_set =
-        B256HashSet::from_iter(filtered_allowance_access_list[0].storage_keys.clone());
+    let balance_slots_set = B256HashSet::from_iter(
+        filtered_balance_access_list
+            .into_iter()
+            .next()
+            .unwrap()
+            .storage_keys,
+    );
+    let allowance_slots_set = B256HashSet::from_iter(
+        filtered_allowance_access_list
+            .into_iter()
+            .next()
+            .unwrap()
+            .storage_keys,
+    );
     let state_diff = B256HashMap::from_iter(
         balance_slots_set
             .symmetric_difference(&allowance_slots_set)

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -130,8 +130,11 @@ pub(crate) static RPC_URL: Lazy<alloy::transports::http::reqwest::Url> = Lazy::n
 });
 
 #[cfg(feature = "extensions")]
-pub(crate) static PROVIDER: Lazy<alloy::providers::ReqwestProvider> =
-    Lazy::new(|| alloy::providers::ProviderBuilder::new().on_http(RPC_URL.clone()));
+pub(crate) static PROVIDER: Lazy<alloy::providers::RootProvider> = Lazy::new(|| {
+    alloy::providers::ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .on_http(RPC_URL.clone())
+});
 
 #[cfg(feature = "extensions")]
 pub(crate) static BLOCK_ID: Lazy<Option<alloy::eips::BlockId>> =


### PR DESCRIPTION
Replaced `Transport` with `Network` across the codebase for improved interface abstraction in Alloy-related modules. Updated dependencies including `alloy` to version `0.11` and `uniswap-lens` to version `0.11` to maintain compatibility. Additionally, made minor adjustments for cleaner and more efficient provider configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the package version and updated several dependency versions.

- **Refactor**
  - Streamlined and unified the network and provider interfaces across components.
  - Simplified configuration logic by removing redundant settings and enhancing method definitions.

- **Tests**
  - Adjusted the testing setup to align with the updated provider configuration.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->