### PR TITLE
refactor: loosen trait bound for `TickDataProvider`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ std = [
     "base64?/std",
     "derive_more/std",
     "fastnum/std",
-    "once_cell/std",
+    "once_cell?/std",
     "serde_json?/std",
     "thiserror/std",
     "uniswap-lens?/std",

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -248,9 +248,7 @@ impl<TP: TickDataProvider> Pool<TP> {
             sqrt_price_limit_x96,
         )
     }
-}
 
-impl<TP: Clone + TickDataProvider> Pool<TP> {
     /// Given an input amount of a token, return the computed output amount
     ///
     /// ## Arguments

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -504,14 +504,7 @@ where
             self.minimum_amount_out_cached(slippage_tolerance, None)?,
         ))
     }
-}
 
-impl<TInput, TOutput, TP> Trade<TInput, TOutput, TP>
-where
-    TInput: BaseCurrency,
-    TOutput: BaseCurrency,
-    TP: Clone + TickDataProvider,
-{
     /// Constructs an exact in trade with the given amount in and route
     ///
     /// ## Arguments
@@ -619,7 +612,14 @@ where
         }
         Self::new(populated_routes, trade_type)
     }
+}
 
+impl<TInput, TOutput, TP> Trade<TInput, TOutput, TP>
+where
+    TInput: BaseCurrency,
+    TOutput: BaseCurrency,
+    TP: Clone + TickDataProvider,
+{
     /// Given a list of pools, and a fixed amount in, returns the top `max_num_results` trades that
     /// go from an input token amount to an output token, making at most `max_hops` hops.
     ///


### PR DESCRIPTION
Removed unnecessary `Clone` trait bound from multiple implementations and functions, streamlining the code where cloning wasn't needed. Updated tests and function signatures accordingly to ensure consistency. Also incremented the package version to reflect these changes.