### PR TITLE
chore: refactor recipient assignment and update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "4.0.0-rc"
+version = "4.0.0-rc2"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -22,15 +22,14 @@ anyhow = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true, default-features = false }
 bnum = "0.12.0"
 derive_more = { version = "2", default-features = false, features = ["deref", "from"] }
-fastnum = { version = "0.1.11", default-features = false, features = ["numtraits"] }
 num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 once_cell = { version = "1.20", optional = true, default-features = false, features = ["critical-section"] }
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.11.1", optional = true }
-uniswap-sdk-core = "4.0.0-rc4"
+uniswap-lens = { version = "0.11", optional = true }
+uniswap-sdk-core = "4.0.0-rc6"
 
 [features]
 default = []
@@ -52,7 +51,6 @@ std = [
     "alloy?/std",
     "base64?/std",
     "derive_more/std",
-    "fastnum/std",
     "once_cell?/std",
     "serde_json?/std",
     "thiserror/std",
@@ -61,12 +59,12 @@ std = [
 ]
 
 [dev-dependencies]
-alloy = { version = "0.11", default-features = false, features = ["provider-anvil-node", "signer-local"] }
+alloy = { version = "0.11", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
 criterion = "0.5.1"
 dotenv = "0.15.0"
 once_cell = "1.20"
 tokio = { version = "1.43", features = ["full"] }
-uniswap_v3_math = "0.5.3"
+uniswap_v3_math = "0.6.0"
 
 [[bench]]
 name = "bit_math"

--- a/src/extensions/price_tick_conversions.rs
+++ b/src/extensions/price_tick_conversions.rs
@@ -377,7 +377,7 @@ pub fn token0_price_to_ratio(
 /// use alloy_primitives::aliases::I24;
 /// use fastnum::dec512;
 /// use num_traits::real::Real;
-/// use uniswap_sdk_core::prelude::BigDecimal;
+/// use uniswap_sdk_core::prelude::*;
 /// use uniswap_v3_sdk::prelude::*;
 ///
 /// let tick_current = I24::from_limbs([200000]);

--- a/src/swap_router.rs
+++ b/src/swap_router.rs
@@ -99,6 +99,11 @@ where
                 .quotient();
         }
     }
+    let intermediate_recipient = if router_must_custody {
+        Address::ZERO
+    } else {
+        recipient
+    };
 
     for trade in trades.iter() {
         for Swap {
@@ -125,11 +130,7 @@ where
                             tokenIn: route.input.wrapped().address(),
                             tokenOut: route.output.wrapped().address(),
                             fee: route.pools[0].fee.into(),
-                            recipient: if router_must_custody {
-                                Address::ZERO
-                            } else {
-                                recipient
-                            },
+                            recipient: intermediate_recipient,
                             amountIn: amount_in,
                             amountOutMinimum: amount_out,
                             sqrtPriceLimitX96: sqrt_price_limit_x96.unwrap_or_default(),
@@ -142,11 +143,7 @@ where
                             tokenIn: route.input.wrapped().address(),
                             tokenOut: route.output.wrapped().address(),
                             fee: route.pools[0].fee.into(),
-                            recipient: if router_must_custody {
-                                Address::ZERO
-                            } else {
-                                recipient
-                            },
+                            recipient: intermediate_recipient,
                             amountOut: amount_out,
                             amountInMaximum: amount_in,
                             sqrtPriceLimitX96: sqrt_price_limit_x96.unwrap_or_default(),
@@ -164,11 +161,7 @@ where
                     TradeType::ExactInput => IV3SwapRouter::exactInputCall {
                         params: IV3SwapRouter::ExactInputParams {
                             path,
-                            recipient: if router_must_custody {
-                                Address::ZERO
-                            } else {
-                                recipient
-                            },
+                            recipient: intermediate_recipient,
                             amountIn: amount_in,
                             amountOutMinimum: amount_out,
                         },
@@ -178,11 +171,7 @@ where
                     TradeType::ExactOutput => IV3SwapRouter::exactOutputCall {
                         params: IV3SwapRouter::ExactOutputParams {
                             path,
-                            recipient: if router_must_custody {
-                                Address::ZERO
-                            } else {
-                                recipient
-                            },
+                            recipient: intermediate_recipient,
                             amountOut: amount_out,
                             amountInMaximum: amount_in,
                         },


### PR DESCRIPTION
Introduced `intermediate_recipient` to simplify recipient assignment logic, reducing redundancy in `swap_router.rs`. Updated dependencies in `Cargo.toml`, with version bumps for `uniswap-sdk-core`, `uniswap_v3_math`, and others. This also includes minor cleanups in import usage and feature definitions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version and revised dependency configurations, including removals and version enhancements to ensure improved maintainability.
  
- **Refactor**
  - Streamlined swap operations by consolidating recipient determination logic.
  - Simplified module import statements to enable broader access to necessary functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->