### PR TITLE
fix(ext): pass factory address in `from_pool_key_with_tick_data_provider`

### DIFF
--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -171,7 +171,7 @@ impl<I: TickIndex> Pool<EphemeralTickMapDataProvider<I>> {
         )
         .await?;
         let tick_data_provider = EphemeralTickMapDataProvider::new(
-            pool.address(None, None),
+            pool.address(None, Some(factory)),
             provider,
             None,
             None,


### PR DESCRIPTION
`from_pool_key_with_tick_data_provider` doesn't pass the correct factory address to `EphemeralTickMapDataProvider::new` hense it fails if `factory: Address` != `FACTORY_ADDRESS`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the initialization process for a key data component by explicitly providing a necessary parameter. This adjustment enhances the consistency and reliability of how addresses are computed in the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->