### PR TITLE
doc: define `CHAIN_ID` in example

### DIFF
--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -18,15 +18,19 @@ use alloy_sol_types::SolCall;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
-// Ethereum mainnet
-const CHAIN_ID: u64 = 1;
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().ok();
     let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
     let provider = ProviderBuilder::new().on_http(rpc_url);
     let block_id = BlockId::from(17000000);
-    let wbtc = token!(1, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
+    const CHAIN_ID: u64 = 1;
+    let wbtc = token!(
+        CHAIN_ID,
+        "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        8,
+        "WBTC"
+    );
     let weth = WETH9::on_chain(CHAIN_ID).unwrap();
 
     // Create a pool with a tick map data provider

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -26,7 +26,7 @@ async fn main() {
     let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
     let provider = ProviderBuilder::new().on_http(rpc_url);
     let block_id = BlockId::from(17000000);
-    let wbtc = token!(CHAIN_ID, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
+    let wbtc = token!(1, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
     let weth = WETH9::on_chain(CHAIN_ID).unwrap();
 
     // Create a pool with a tick map data provider

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -18,18 +18,20 @@ use alloy_sol_types::SolCall;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
+const CHAIN_ID: u64 = 1;
+
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().ok();
     let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
     let provider = ProviderBuilder::new().on_http(rpc_url);
     let block_id = BlockId::from(17000000);
-    let wbtc = token!(1, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
-    let weth = WETH9::on_chain(1).unwrap();
+    let wbtc = token!(CHAIN_ID, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
+    let weth = WETH9::on_chain(CHAIN_ID).unwrap();
 
     // Create a pool with a tick map data provider
     let pool = Pool::<EphemeralTickMapDataProvider>::from_pool_key_with_tick_data_provider(
-        1,
+        CHAIN_ID,
         FACTORY_ADDRESS,
         wbtc.address(),
         weth.address(),
@@ -49,7 +51,7 @@ async fn main() {
     let route = Route::new(vec![pool], wbtc, weth);
     let params = quote_call_parameters(&route, &amount_in, TradeType::ExactInput, None);
     let tx = TransactionRequest::default()
-        .to(*QUOTER_ADDRESSES.get(&1).unwrap())
+        .to(*QUOTER_ADDRESSES.get(&CHAIN_ID).unwrap())
         .input(params.calldata.into());
     let res = provider.call(tx).block(block_id).await.unwrap();
     let amount_out = IQuoter::quoteExactInputSingleCall::abi_decode_returns(res.as_ref(), true)

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -18,8 +18,8 @@ use alloy_sol_types::SolCall;
 use uniswap_sdk_core::{prelude::*, token};
 use uniswap_v3_sdk::prelude::*;
 
+// Ethereum mainnet
 const CHAIN_ID: u64 = 1;
-
 #[tokio::main]
 async fn main() {
     dotenv::dotenv().ok();

--- a/src/self_permit.rs
+++ b/src/self_permit.rs
@@ -124,7 +124,7 @@ pub enum PermitOptions {
 impl StandardPermitArguments {
     #[inline]
     #[must_use]
-    pub fn new(r: U256, s: U256, v: bool, amount: U256, deadline: U256) -> Self {
+    pub const fn new(r: U256, s: U256, v: bool, amount: U256, deadline: U256) -> Self {
         Self {
             signature: PrimitiveSignature::new(r, s, v),
             amount,
@@ -136,7 +136,7 @@ impl StandardPermitArguments {
 impl AllowedPermitArguments {
     #[inline]
     #[must_use]
-    pub fn new(r: U256, s: U256, v: bool, nonce: U256, expiry: U256) -> Self {
+    pub const fn new(r: U256, s: U256, v: bool, nonce: U256, expiry: U256) -> Self {
         Self {
             signature: PrimitiveSignature::new(r, s, v),
             nonce,


### PR DESCRIPTION
This PR make changes to the `from_pool_key_with_tick_data_provider` example.

Issue
- None. Just think it may be more readable.

Add
- `CHAIN_ID` as const

Update
- method calls to use `CHAIN_ID` instead of `1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Consolidated a key network configuration parameter into a single, unified setting.
  - Standardized network identifier usage to improve consistency and maintainability, paving the way for smoother future updates without impacting visible functionality.
  - Enhanced method signatures to allow for compile-time evaluation, improving potential optimizations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->