### PR TITLE
chore: update dependencies and refactor method calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "3.6.2"
+version = "3.7.0"
 edition = "2021"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
 description = "Uniswap V3 SDK for Rust"
@@ -15,7 +15,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.11", optional = true, default-features = false, features = ["contract"] }
+alloy = { version = "0.12", optional = true, default-features = false, features = ["contract"] }
 alloy-primitives = { version = "0.8", default-features = false }
 alloy-sol-types = { version = "0.8", default-features = false }
 anyhow = { version = "1.0", optional = true }
@@ -28,8 +28,15 @@ once_cell = { version = "1.20", default-features = false, features = ["critical-
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.11.1", optional = true }
-uniswap-sdk-core = "3.6.0"
+uniswap-lens = { version = "0.12", optional = true }
+uniswap-sdk-core = ">=3.6.1, <3.7.0"
+
+[dev-dependencies]
+alloy = { version = "0.12", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
+criterion = "0.5.1"
+dotenv = "0.15.0"
+tokio = { version = "1.43", features = ["full"] }
+uniswap_v3_math = "0.6.0"
 
 [features]
 default = []
@@ -56,13 +63,6 @@ std = [
     "uniswap-lens?/std",
     "uniswap-sdk-core/std"
 ]
-
-[dev-dependencies]
-alloy = { version = "0.11", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
-criterion = "0.5.1"
-dotenv = "0.15.0"
-tokio = { version = "1.43", features = ["full"] }
-uniswap_v3_math = "0.6.0"
 
 [[bench]]
 name = "bit_math"

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -51,7 +51,7 @@ async fn main() {
     let tx = TransactionRequest::default()
         .to(*QUOTER_ADDRESSES.get(&1).unwrap())
         .input(params.calldata.into());
-    let res = provider.call(&tx).block(block_id).await.unwrap();
+    let res = provider.call(tx).block(block_id).await.unwrap();
     let amount_out = IQuoter::quoteExactInputSingleCall::abi_decode_returns(res.as_ref(), true)
         .unwrap()
         .amountOut;

--- a/examples/swap_router.rs
+++ b/examples/swap_router.rs
@@ -58,7 +58,7 @@ async fn main() {
     let tx = TransactionRequest::default()
         .to(*QUOTER_ADDRESSES.get(&1).unwrap())
         .input(params.calldata.into());
-    let res = provider.call(&tx).block(block_id).await.unwrap();
+    let res = provider.call(tx).block(block_id).await.unwrap();
     let amount_out = IQuoter::quoteExactInputSingleCall::abi_decode_returns(res.as_ref(), true)
         .unwrap()
         .amountOut;

--- a/src/extensions/state_overrides.rs
+++ b/src/extensions/state_overrides.rs
@@ -108,7 +108,7 @@ mod tests {
         let balance = usdc
             .balanceOf(owner)
             .call()
-            .overrides(&overrides)
+            .overrides(overrides.clone())
             .await
             .unwrap()
             ._0;
@@ -116,7 +116,7 @@ mod tests {
         let allowance = usdc
             .allowance(owner, npm)
             .call()
-            .overrides(&overrides)
+            .overrides(overrides)
             .await
             .unwrap()
             ._0;

--- a/src/self_permit.rs
+++ b/src/self_permit.rs
@@ -124,7 +124,7 @@ pub enum PermitOptions {
 impl StandardPermitArguments {
     #[inline]
     #[must_use]
-    pub fn new(r: U256, s: U256, v: bool, amount: U256, deadline: U256) -> Self {
+    pub const fn new(r: U256, s: U256, v: bool, amount: U256, deadline: U256) -> Self {
         Self {
             signature: PrimitiveSignature::new(r, s, v),
             amount,
@@ -136,7 +136,7 @@ impl StandardPermitArguments {
 impl AllowedPermitArguments {
     #[inline]
     #[must_use]
-    pub fn new(r: U256, s: U256, v: bool, nonce: U256, expiry: U256) -> Self {
+    pub const fn new(r: U256, s: U256, v: bool, nonce: U256, expiry: U256) -> Self {
         Self {
             signature: PrimitiveSignature::new(r, s, v),
             nonce,


### PR DESCRIPTION
Updated the crate version to 3.7.0 and upgraded dependencies like `alloy` and `uniswap-sdk-core`. Removed unnecessary references in method calls to align with updated function signatures. Minor code adjustments improve consistency and maintainability.