### PR TITLE
chore: upgrade dependencies and bump version to 4.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -16,7 +16,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.12", optional = true, default-features = false, features = ["contract"] }
+alloy = { version = "0.13", optional = true, default-features = false, features = ["contract"] }
 alloy-primitives = { version = "0.8", default-features = false }
 alloy-sol-types = { version = "0.8", default-features = false }
 anyhow = { version = "1.0", optional = true }
@@ -28,8 +28,16 @@ once_cell = { version = "1.20", optional = true, default-features = false, featu
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.12", optional = true }
-uniswap-sdk-core = "4.0.0"
+uniswap-lens = { version = "0.13", optional = true }
+uniswap-sdk-core = "4.0.1"
+
+[dev-dependencies]
+alloy = { version = "0.13", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
+criterion = "0.5.1"
+dotenv = "0.15.0"
+once_cell = "1.20"
+tokio = { version = "1.44", features = ["full"] }
+uniswap_v3_math = "0.6.0"
 
 [features]
 default = []
@@ -57,14 +65,6 @@ std = [
     "uniswap-lens?/std",
     "uniswap-sdk-core/std"
 ]
-
-[dev-dependencies]
-alloy = { version = "0.12", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
-criterion = "0.5.1"
-dotenv = "0.15.0"
-once_cell = "1.20"
-tokio = { version = "1.43", features = ["full"] }
-uniswap_v3_math = "0.6.0"
 
 [[bench]]
 name = "bit_math"


### PR DESCRIPTION
Upgraded `alloy` to version 0.13 and updated related dependencies (`uniswap-lens`, `uniswap-sdk-core`). Bumped package version to 4.1.0 to reflect these changes. Adjusted `dev-dependencies` for consistency and compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
  - Updated the package to version 4.1.0, marking a series of performance and stability enhancements.
  - Upgraded key dependencies to ensure improved reliability and a robust system.
  - Refined development tooling to facilitate efficient testing and accelerate future improvements.
  - These changes provide a stronger foundation for upcoming updates, contributing to a smoother overall experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->