### PR TITLE
refactor!: enhance `SimpleTickDataProvider` and improve README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "4.2.0"
+version = "4.3.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -29,7 +29,7 @@ regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
 uniswap-lens = { version = "0.13", optional = true }
-uniswap-sdk-core = "4.0.1"
+uniswap-sdk-core = "4.1.0"
 
 [dev-dependencies]
 alloy = { version = "0.13", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Uniswap V3 SDK Rust
 
 [![Rust CI](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/actions/workflows/rust.yml/badge.svg)](https://github.com/shuhuiluo/uniswap-v3-sdk-rs/actions/workflows/rust.yml)
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/shuhuiluo/uniswap-v3-sdk-rs?logo=rust&label=CodeRabbit&color=orange)
 [![docs.rs](https://img.shields.io/docsrs/uniswap-v3-sdk)](https://docs.rs/uniswap-v3-sdk/latest)
 [![crates.io](https://img.shields.io/crates/v/uniswap-v3-sdk.svg)](https://crates.io/crates/uniswap-v3-sdk)
 
@@ -20,9 +19,9 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 - An [`extensions`](./src/extensions) feature for additional functionalities related to Uniswap V3, including:
 
     - [`pool`](./src/extensions/pool.rs) module for creating a `Pool` struct from a pool key and fetching the
-      liquidity map within a tick range for the specified pool, using RPC client
+      liquidity map within a tick range for the specified pool, using an RPC provider
     - [`position`](./src/extensions/position.rs) module for creating a `Position` struct from a token id and fetching
-      the state and pool for all positions of the specified owner, using RPC client, etc
+      the state and pool for all positions of the specified owner, etc., using an RPC provider
     - [`price_tick_conversions`](./src/extensions/price_tick_conversions.rs) module for converting between prices and
       ticks
     - [`simple_tick_data_provider`](./src/extensions/simple_tick_data_provider.rs) module for fetching tick data
@@ -53,7 +52,7 @@ It is feature-complete with unit tests matching the TypeScript SDK.
 When updating this, also update:
 - clippy.toml
 - Cargo.toml
-- .github/workflows/ci.yml
+- .github/workflows/rust.yml
 -->
 
 The current MSRV (minimum supported rust version) is 1.83.
@@ -63,7 +62,7 @@ The current MSRV (minimum supported rust version) is 1.83.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "4.2.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "4.3.0", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/src/extensions/ephemeral_tick_data_provider.rs
+++ b/src/extensions/ephemeral_tick_data_provider.rs
@@ -84,7 +84,7 @@ mod tests {
             PROVIDER.clone(),
             None,
             None,
-            *BLOCK_ID,
+            BLOCK_ID,
         )
         .await?;
         assert!(!provider.ticks.is_empty());

--- a/src/extensions/ephemeral_tick_map_data_provider.rs
+++ b/src/extensions/ephemeral_tick_map_data_provider.rs
@@ -60,7 +60,7 @@ mod tests {
             PROVIDER.clone(),
             None,
             None,
-            *BLOCK_ID,
+            BLOCK_ID,
         )
         .await?;
         // [-887270, -92110, 100, 110, 22990, ...]

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -330,7 +330,7 @@ mod tests {
             address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"),
             FeeAmount::LOW,
             PROVIDER.clone(),
-            *BLOCK_ID,
+            BLOCK_ID,
         )
         .await
         .unwrap()
@@ -358,7 +358,7 @@ mod tests {
             tick_lower,
             tick_upper,
             PROVIDER.clone(),
-            *BLOCK_ID,
+            BLOCK_ID,
             None,
             None,
         )

--- a/src/extensions/simple_tick_data_provider.rs
+++ b/src/extensions/simple_tick_data_provider.rs
@@ -4,7 +4,7 @@
 use crate::prelude::*;
 use alloy::{
     eips::{BlockId, BlockNumberOrTag},
-    network::Network,
+    network::{Ethereum, Network},
     providers::Provider,
     sol,
 };
@@ -32,7 +32,7 @@ sol! {
 
 /// A data provider that fetches tick data from a Uniswap V3 pool contract on the fly.
 #[derive(Clone, Debug)]
-pub struct SimpleTickDataProvider<N, P, I = I24>
+pub struct SimpleTickDataProvider<P, N = Ethereum, I = I24>
 where
     N: Network,
     P: Provider<N>,
@@ -44,7 +44,7 @@ where
     _network: core::marker::PhantomData<N>,
 }
 
-impl<N, P, I> SimpleTickDataProvider<N, P, I>
+impl<P, N, I> SimpleTickDataProvider<P, N, I>
 where
     N: Network,
     P: Provider<N>,
@@ -59,9 +59,15 @@ where
             _network: core::marker::PhantomData,
         }
     }
+
+    #[inline]
+    pub const fn block_id(mut self, block_id: Option<BlockId>) -> Self {
+        self.block_id = block_id;
+        self
+    }
 }
 
-impl<N, P, I> TickBitMapProvider for SimpleTickDataProvider<N, P, I>
+impl<P, N, I> TickBitMapProvider for SimpleTickDataProvider<P, N, I>
 where
     N: Network,
     P: Provider<N>,
@@ -84,7 +90,7 @@ where
     }
 }
 
-impl<N, P, I> TickDataProvider for SimpleTickDataProvider<N, P, I>
+impl<P, N, I> TickDataProvider for SimpleTickDataProvider<P, N, I>
 where
     N: Network,
     P: Provider<N>,
@@ -135,7 +141,7 @@ mod tests {
         let provider = SimpleTickDataProvider::new(
             address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
             PROVIDER.clone(),
-            *BLOCK_ID,
+            BLOCK_ID,
         );
         // [-887270, -92110, 100, 110, 22990, ...]
         let tick = provider.get_tick(-92110).await?;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -167,18 +167,28 @@ pub(crate) fn make_pool(token0: Token, token1: Token) -> Pool<TickListDataProvid
 }
 
 #[cfg(feature = "extensions")]
-pub(crate) static RPC_URL: Lazy<alloy::transports::http::reqwest::Url> = Lazy::new(|| {
-    dotenv::dotenv().ok();
-    std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap()
-});
+pub(crate) use extensions::*;
 
 #[cfg(feature = "extensions")]
-pub(crate) static PROVIDER: Lazy<alloy::providers::RootProvider> = Lazy::new(|| {
-    alloy::providers::ProviderBuilder::new()
-        .disable_recommended_fillers()
-        .on_http(RPC_URL.clone())
-});
+mod extensions {
+    use alloy::{
+        eips::{BlockId, BlockNumberOrTag},
+        providers::{ProviderBuilder, RootProvider},
+        transports::http::reqwest::Url,
+    };
+    use once_cell::sync::Lazy;
 
-#[cfg(feature = "extensions")]
-pub(crate) static BLOCK_ID: Lazy<Option<alloy::eips::BlockId>> =
-    Lazy::new(|| Some(alloy::eips::BlockId::from(17000000)));
+    pub(crate) static RPC_URL: Lazy<Url> = Lazy::new(|| {
+        dotenv::dotenv().ok();
+        std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap()
+    });
+
+    pub(crate) static PROVIDER: Lazy<RootProvider> = Lazy::new(|| {
+        ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .on_http(RPC_URL.clone())
+    });
+
+    pub(crate) const BLOCK_ID: Option<BlockId> =
+        Some(BlockId::Number(BlockNumberOrTag::Number(17000000)));
+}


### PR DESCRIPTION
* refactor!: enhance `SimpleTickDataProvider` and improve README

Reorganize type parameters and add a `block_id` method for better usability. Update to version 4.3.0 in Cargo.toml and README, while refining README content for readability and accuracy.

* Remove dereferencing of `BLOCK_ID` and refactor `tests` module

Replaced `*BLOCK_ID` with `BLOCK_ID` for consistency and to remove unnecessary dereferencing. Additionally, refactored the `tests.rs` module to encapsulate extension-related definitions within a dedicated module, improving organization and clarity. Updated the `uniswap-sdk-core` dependency version to `4.1.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README to clarify terminology, update workflow references, and reflect the latest dependency version.
- **Refactor**
  - Improved test code by passing block IDs directly instead of by reference.
  - Consolidated test constants and providers into a dedicated internal module for better organization.
  - Adjusted the generic parameter order and defaults for the SimpleTickDataProvider and added a builder-style method for setting block IDs.
- **Chores**
  - Updated dependency versions to the latest releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->