### PR TITLE
chore: bump alloy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.13", optional = true, default-features = false, features = ["contract"] }
+alloy = { version = "0.14", optional = true, default-features = false, features = ["contract"] }
 alloy-primitives = { version = "0.8", default-features = false }
 alloy-sol-types = { version = "0.8", default-features = false }
 anyhow = { version = "1.0", optional = true }


### PR DESCRIPTION
Bump alloy to the latest version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the version of the optional `alloy` dependency to 0.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->