### PR TITLE
refactor!: bump alloy to 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "3.9.0"
+version = "3.10.0"
 edition = "2021"
 rust-version = "1.82"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -16,9 +16,9 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "0.13", optional = true, default-features = false, features = ["contract"] }
-alloy-primitives = { version = "0.8", default-features = false }
-alloy-sol-types = { version = "0.8", default-features = false }
+alloy = { version = "1.0.1", optional = true, default-features = false, features = ["contract"] }
+alloy-primitives = { version = "1.0", default-features = false }
+alloy-sol-types = { version = "1.0", default-features = false }
 anyhow = { version = "1.0", optional = true }
 base64 = { version = "0.22", optional = true, default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "from"] }
@@ -29,14 +29,14 @@ once_cell = { version = "1.20", default-features = false, features = ["critical-
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.13", optional = true }
-uniswap-sdk-core = ">=3.6.2, <3.7.0"
+uniswap-lens = { version = "0.15", optional = true }
+uniswap-sdk-core = "3.7.1"
 
 [dev-dependencies]
-alloy = { version = "0.13", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
+alloy = { version = "1.0.1", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
 criterion = "0.5.1"
 dotenv = "0.15.0"
-tokio = { version = "1.44", features = ["full"] }
+tokio = { version = "1.45", features = ["full"] }
 uniswap_v3_math = "0.6.0"
 
 [features]

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The current MSRV (minimum supported rust version) is 1.82.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "3.9.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "3.10.0", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -22,14 +22,20 @@ use uniswap_v3_sdk::prelude::*;
 async fn main() {
     dotenv::dotenv().ok();
     let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
-    let provider = ProviderBuilder::new().on_http(rpc_url);
+    let provider = ProviderBuilder::new().connect_http(rpc_url);
     let block_id = BlockId::from(17000000);
-    let wbtc = token!(1, "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599", 8, "WBTC");
-    let weth = WETH9::on_chain(1).unwrap();
+    const CHAIN_ID: u64 = 1;
+    let wbtc = token!(
+        CHAIN_ID,
+        "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+        8,
+        "WBTC"
+    );
+    let weth = WETH9::on_chain(CHAIN_ID).unwrap();
 
     // Create a pool with a tick map data provider
     let pool = Pool::<EphemeralTickMapDataProvider>::from_pool_key_with_tick_data_provider(
-        1,
+        CHAIN_ID,
         FACTORY_ADDRESS,
         wbtc.address(),
         weth.address(),
@@ -49,12 +55,11 @@ async fn main() {
     let route = Route::new(vec![pool], wbtc, weth);
     let params = quote_call_parameters(&route, &amount_in, TradeType::ExactInput, None);
     let tx = TransactionRequest::default()
-        .to(*QUOTER_ADDRESSES.get(&1).unwrap())
+        .to(*QUOTER_ADDRESSES.get(&CHAIN_ID).unwrap())
         .input(params.calldata.into());
     let res = provider.call(tx).block(block_id).await.unwrap();
-    let amount_out = IQuoter::quoteExactInputSingleCall::abi_decode_returns(res.as_ref(), true)
-        .unwrap()
-        .amountOut;
+    let amount_out =
+        IQuoter::quoteExactInputSingleCall::abi_decode_returns_validate(res.as_ref()).unwrap();
     println!("Quoter amount out: {}", amount_out);
 
     // Compare local calculation with on-chain quoter to ensure accuracy

--- a/examples/nonfungible_position_manager.rs
+++ b/examples/nonfungible_position_manager.rs
@@ -30,7 +30,7 @@ async fn main() {
     let npm = *NONFUNGIBLE_POSITION_MANAGER_ADDRESSES.get(&1).unwrap();
 
     // Create an Anvil fork
-    let provider = ProviderBuilder::new().on_anvil_with_config(|anvil| {
+    let provider = ProviderBuilder::new().connect_anvil_with_config(|anvil| {
         anvil
             .fork(rpc_url)
             .fork_block_number(block_id.as_u64().unwrap())
@@ -111,8 +111,7 @@ async fn main() {
             .balanceOf(account.address())
             .call()
             .await
-            .unwrap()
-            ._0,
+            .unwrap(),
         U256::ZERO
     );
 }
@@ -154,7 +153,6 @@ where
         .call()
         .await
         .unwrap()
-        ._0
 }
 
 /// Burn a position with a permit

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -547,14 +547,12 @@ where
         trade_type: TradeType,
     ) -> Result<Self, Error> {
         let mut token_amount: CurrencyAmount<Token> = amount.wrapped_owned()?;
+        let currency = amount.meta.currency;
         let input_amount: CurrencyAmount<TInput>;
         let output_amount: CurrencyAmount<TOutput>;
         match trade_type {
             TradeType::ExactInput => {
-                assert!(
-                    amount.currency.wrapped().equals(route.input.wrapped()),
-                    "INPUT"
-                );
+                assert!(currency.wrapped().equals(route.input.wrapped()), "INPUT");
                 for pool in &route.pools {
                     token_amount = pool.get_output_amount(&token_amount, None).await?;
                 }
@@ -570,10 +568,7 @@ where
                 )?;
             }
             TradeType::ExactOutput => {
-                assert!(
-                    amount.currency.wrapped().equals(route.output.wrapped()),
-                    "OUTPUT"
-                );
+                assert!(currency.wrapped().equals(route.output.wrapped()), "OUTPUT");
                 for pool in route.pools.iter().rev() {
                     token_amount = pool.get_input_amount(&token_amount, None).await?;
                 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,13 +3,6 @@
 #[cfg(doc)]
 use crate::prelude::*;
 
-#[cfg(feature = "extensions")]
-use alloy::contract::Error as ContractError;
-#[cfg(feature = "extensions")]
-use alloy::providers::MulticallError;
-#[cfg(feature = "extensions")]
-use uniswap_lens::error::Error as LensError;
-
 use alloy_primitives::{aliases::I24, U160};
 use uniswap_sdk_core::error::Error as CoreError;
 
@@ -67,15 +60,15 @@ pub enum Error {
 
     #[cfg(feature = "extensions")]
     #[error("{0}")]
-    ContractError(#[from] ContractError),
+    ContractError(#[from] alloy::contract::Error),
 
     #[cfg(feature = "extensions")]
     #[error("{0}")]
-    LensError(#[from] LensError),
+    LensError(#[from] uniswap_lens::error::Error),
 
     #[cfg(feature = "extensions")]
     #[error("{0}")]
-    MulticallError(#[from] MulticallError),
+    MulticallError(#[from] alloy::providers::MulticallError),
 
     #[cfg(feature = "extensions")]
     #[error("Invalid access list")]
@@ -95,6 +88,6 @@ pub enum TickListError {
 #[cfg(feature = "extensions")]
 impl From<alloy::transports::TransportError> for Error {
     fn from(e: alloy::transports::TransportError) -> Self {
-        Self::ContractError(ContractError::TransportError(e))
+        Self::ContractError(alloy::contract::Error::TransportError(e))
     }
 }

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -26,7 +26,7 @@ pub fn get_pool_contract<N, P>(
     token_b: Address,
     fee: FeeAmount,
     provider: P,
-) -> IUniswapV3PoolInstance<(), P, N>
+) -> IUniswapV3PoolInstance<P, N>
 where
     N: Network,
     P: Provider<N>,
@@ -96,20 +96,20 @@ impl Pool {
             token!(
                 chain_id,
                 token_a,
-                token_a_decimals._0,
-                token_a_symbol._0,
-                token_a_name._0
+                token_a_decimals,
+                token_a_symbol,
+                token_a_name
             ),
             token!(
                 chain_id,
                 token_b,
-                token_b_decimals._0,
-                token_b_symbol._0,
-                token_b_name._0
+                token_b_decimals,
+                token_b_symbol,
+                token_b_name
             ),
             fee,
             sqrt_price_x96,
-            liquidity._0,
+            liquidity,
         )
     }
 }
@@ -142,7 +142,7 @@ impl<I: TickIndex> Pool<EphemeralTickMapDataProvider<I>> {
     /// async fn main() {
     ///     dotenv::dotenv().ok();
     ///     let rpc_url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
-    ///     let provider = ProviderBuilder::new().on_http(rpc_url);
+    ///     let provider = ProviderBuilder::new().connect_http(rpc_url);
     ///     let block_id = Some(BlockId::from(17000000));
     ///     let pool = Pool::<EphemeralTickMapDataProvider>::from_pool_key_with_tick_data_provider(
     ///         1,

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -29,7 +29,7 @@ use uniswap_sdk_core::{prelude::*, token};
 pub const fn get_nonfungible_position_manager_contract<N, P>(
     nonfungible_position_manager: Address,
     provider: P,
-) -> IUniswapV3NonfungiblePositionManagerInstance<(), P, N>
+) -> IUniswapV3NonfungiblePositionManagerInstance<P, N>
 where
     N: Network,
     P: Provider<N>,
@@ -79,7 +79,7 @@ where
     ) = multicall.block(block_id_).aggregate().await?;
     let pool = Pool::from_pool_key(
         chain_id,
-        factory._0,
+        factory,
         token0,
         token1,
         fee.into(),
@@ -276,7 +276,7 @@ where
         .add(npm_contract.positions(token_id));
     let (factory, position) = multicall.block(block_id_).aggregate().await?;
     let pool_contract = get_pool_contract(
-        factory._0,
+        factory,
         position.token0,
         position.token1,
         position.fee.into(),
@@ -310,10 +310,10 @@ where
         )
     } else {
         (
-            fee_growth_global_0x128._0
+            fee_growth_global_0x128
                 - fee_growth_outside_0x128_lower
                 - fee_growth_outside_0x128_upper,
-            fee_growth_global_1x128._0
+            fee_growth_global_1x128
                 - fee_growth_outside_1x128_lower
                 - fee_growth_outside_1x128_upper,
         )
@@ -354,8 +354,7 @@ where
         .tokenURI(token_id)
         .block(block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)))
         .call()
-        .await?
-        ._0;
+        .await?;
     let json_uri = base64::Engine::decode(
         &base64::engine::general_purpose::URL_SAFE,
         uri.replace("data:application/json;base64,", ""),
@@ -472,6 +471,7 @@ where
 mod tests {
     use super::*;
     use crate::tests::PROVIDER;
+    use alloy::providers::MulticallBuilder;
     use alloy_primitives::{address, uint};
     use core::str::FromStr;
     use num_traits::{Signed, Zero};
@@ -528,19 +528,17 @@ mod tests {
             .call()
             .await
             .unwrap()
-            .balance
             .into_limbs()[0] as usize;
         assert_eq!(positions.len(), balance);
-        // let mut multicall = Multicall::new_with_chain_id(provider, None, Some(1u64)).unwrap();
-        // multicall.block = Some(block_id);
-        // multicall.add_calls(
-        //     false,
-        //     (0..balance).map(|i| npm_contract.token_of_owner_by_index(owner,
-        // types::U256::from(i))), );
-        // let token_ids: Vec<types::U256> = multicall.call_array().await.unwrap();
-        // token_ids.into_iter().enumerate().for_each(|(i, token_id)| {
-        //     assert_eq!(token_id, positions[i].token_id);
-        // });
+        let mut multicall = MulticallBuilder::new_dynamic(provider);
+        for i in 0..balance {
+            multicall =
+                multicall.add_dynamic(npm_contract.tokenOfOwnerByIndex(owner, U256::from(i)));
+        }
+        let token_ids: Vec<U256> = multicall.block(block_id).aggregate().await.unwrap();
+        token_ids.into_iter().enumerate().for_each(|(i, token_id)| {
+            assert_eq!(token_id, positions[i].tokenId);
+        });
     }
 
     #[tokio::test]

--- a/src/extensions/price_tick_conversions.rs
+++ b/src/extensions/price_tick_conversions.rs
@@ -68,7 +68,8 @@ where
     };
     let decimals = fraction.len();
     let without_decimals =
-        <BigInt as core::str::FromStr>::from_str(&alloc::format!("{}{}", whole, fraction))?;
+        <BigInt as core::str::FromStr>::from_str(&alloc::format!("{}{}", whole, fraction))
+            .map_err(|e| anyhow::anyhow!("Invalid price string: {}", e))?;
     let numerator = without_decimals * BigInt::from(10).pow(quote_token.decimals() as u32);
     let denominator = BigInt::from(10).pow(decimals as u32 + base_token.decimals() as u32);
     Ok(Price::new(base_token, quote_token, denominator, numerator))

--- a/src/extensions/simple_tick_data_provider.rs
+++ b/src/extensions/simple_tick_data_provider.rs
@@ -38,7 +38,7 @@ where
     P: Provider<N>,
     I: TickIndex,
 {
-    pub pool: IUniswapV3PoolState::IUniswapV3PoolStateInstance<(), P, N>,
+    pub pool: IUniswapV3PoolState::IUniswapV3PoolStateInstance<P, N>,
     pub block_id: Option<BlockId>,
     _tick_index: core::marker::PhantomData<I>,
     _network: core::marker::PhantomData<N>,
@@ -86,7 +86,7 @@ where
             .block(block_id)
             .call()
             .await?;
-        Ok(U256::from(word._0))
+        Ok(U256::from(word))
     }
 }
 

--- a/src/extensions/state_overrides.rs
+++ b/src/extensions/state_overrides.rs
@@ -110,16 +110,14 @@ mod tests {
             .call()
             .overrides(overrides.clone())
             .await
-            .unwrap()
-            ._0;
+            .unwrap();
         assert_eq!(balance, amount);
         let allowance = usdc
             .allowance(owner, npm)
             .call()
             .overrides(overrides)
             .await
-            .unwrap()
-            ._0;
+            .unwrap();
         assert_eq!(allowance, amount);
     }
 }

--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -23,7 +23,7 @@ where
     E: AsRef<[u8]>,
     B: From<Bytes>,
 {
-    IMulticall::multicallCall::abi_decode(encoded.as_ref(), true)
+    IMulticall::multicallCall::abi_decode_validate(encoded.as_ref())
         .map(|decoded| decoded.data.into_iter().map(Into::into).collect())
 }
 

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -1,5 +1,5 @@
 use crate::prelude::{Error, *};
-use alloy_primitives::{Bytes, PrimitiveSignature, B256, U256};
+use alloy_primitives::{Bytes, Signature, B256, U256};
 use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall, SolStruct};
 use num_traits::ToPrimitive;
 use uniswap_sdk_core::prelude::*;
@@ -85,7 +85,7 @@ impl NFTPermitData {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NFTPermitOptions {
-    pub signature: PrimitiveSignature,
+    pub signature: Signature,
     pub deadline: U256,
     pub spender: Address,
 }
@@ -447,7 +447,7 @@ pub fn safe_transfer_from_parameters(options: SafeTransferOptions) -> MethodPara
 ///
 /// ```
 /// use alloy::signers::{local::PrivateKeySigner, SignerSync};
-/// use alloy_primitives::{address, b256, uint, PrimitiveSignature, B256};
+/// use alloy_primitives::{address, b256, uint, Signature, B256};
 /// use alloy_sol_types::SolStruct;
 /// use uniswap_v3_sdk::prelude::*;
 ///
@@ -468,7 +468,7 @@ pub fn safe_transfer_from_parameters(options: SafeTransferOptions) -> MethodPara
 /// let hash: B256 = data.eip712_signing_hash();
 ///
 /// let signer = PrivateKeySigner::random();
-/// let signature: PrimitiveSignature = signer.sign_hash_sync(&hash).unwrap();
+/// let signature: Signature = signer.sign_hash_sync(&hash).unwrap();
 /// assert_eq!(
 ///     signature.recover_address_from_prehash(&hash).unwrap(),
 ///     signer.address()

--- a/src/self_permit.rs
+++ b/src/self_permit.rs
@@ -1,5 +1,5 @@
 use super::abi::ISelfPermit;
-use alloy_primitives::{Bytes, PrimitiveSignature, B256, U256};
+use alloy_primitives::{Bytes, Signature, B256, U256};
 use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall, SolStruct};
 use uniswap_sdk_core::prelude::*;
 
@@ -35,7 +35,7 @@ impl<P: SolStruct> ERC20PermitData<P> {
 ///
 /// ```
 /// use alloy::signers::{local::PrivateKeySigner, SignerSync};
-/// use alloy_primitives::{address, b256, uint, PrimitiveSignature, B256};
+/// use alloy_primitives::{address, b256, uint, Signature, B256};
 /// use alloy_sol_types::SolStruct;
 /// use uniswap_v3_sdk::prelude::*;
 ///
@@ -74,7 +74,7 @@ impl<P: SolStruct> ERC20PermitData<P> {
 /// // Derive the EIP-712 signing hash.
 /// let hash: B256 = permit_data.eip712_signing_hash();
 ///
-/// let signature: PrimitiveSignature = signer.sign_hash_sync(&hash).unwrap();
+/// let signature: Signature = signer.sign_hash_sync(&hash).unwrap();
 /// assert_eq!(
 ///     signature.recover_address_from_prehash(&hash).unwrap(),
 ///     signer.address()
@@ -103,14 +103,14 @@ pub fn get_erc20_permit_data<P: SolStruct>(
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct StandardPermitArguments {
-    pub signature: PrimitiveSignature,
+    pub signature: Signature,
     pub amount: U256,
     pub deadline: U256,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AllowedPermitArguments {
-    pub signature: PrimitiveSignature,
+    pub signature: Signature,
     pub nonce: U256,
     pub expiry: U256,
 }
@@ -126,7 +126,7 @@ impl StandardPermitArguments {
     #[must_use]
     pub const fn new(r: U256, s: U256, v: bool, amount: U256, deadline: U256) -> Self {
         Self {
-            signature: PrimitiveSignature::new(r, s, v),
+            signature: Signature::new(r, s, v),
             amount,
             deadline,
         }
@@ -138,7 +138,7 @@ impl AllowedPermitArguments {
     #[must_use]
     pub const fn new(r: U256, s: U256, v: bool, nonce: U256, expiry: U256) -> Self {
         Self {
-            signature: PrimitiveSignature::new(r, s, v),
+            signature: Signature::new(r, s, v),
             nonce,
             expiry,
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -186,7 +186,7 @@ mod extensions {
     pub(crate) static PROVIDER: Lazy<RootProvider> = Lazy::new(|| {
         ProviderBuilder::new()
             .disable_recommended_fillers()
-            .on_http(RPC_URL.clone())
+            .connect_http(RPC_URL.clone())
     });
 
     pub(crate) const BLOCK_ID: Option<BlockId> =


### PR DESCRIPTION
Replaced deprecated `PrimitiveSignature` with `Signature` and updated method calls for improved validation and consistency. Upgraded several dependencies, including `alloy` and `uniswap-sdk-core`, and adjusted function signatures and API usage throughout the codebase to align with the new library versions. Incremented package version to `3.10.0`.