### PR TITLE
Add ObserverTickDataProvider with on-chain tick data fetching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
 uniswap-lens = { version = "0.15", optional = true }
 uniswap-sdk-core = "5.1.0"
+uni-obrv = "0.1.2"
+
 
 [dev-dependencies]
 alloy = { version = "1.0.1", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -9,7 +9,11 @@ mod simple_tick_data_provider;
 mod state_overrides;
 mod tick_bit_map;
 mod tick_map;
+mod uni_observer_tick_data_provider;
+mod uni_observer_tick_map_data_provider;
 
+pub use uni_observer_tick_data_provider::ObserverTickDataProvider;
+pub use uni_observer_tick_map_data_provider::UniObserverTickMapDataProvider;
 pub use ephemeral_tick_data_provider::EphemeralTickDataProvider;
 pub use ephemeral_tick_map_data_provider::EphemeralTickMapDataProvider;
 pub use pool::*;

--- a/src/extensions/uni_observer_tick_data_provider.rs
+++ b/src/extensions/uni_observer_tick_data_provider.rs
@@ -1,0 +1,126 @@
+//! ## Uni Observer Tick Data Provider
+//! A data provider that fetches ticks using an [Helper contract](https://github.com/Un4G173N/uni_obrv) in a single `eth_call`.
+
+use crate::prelude::*;
+use alloc::vec::Vec;
+use alloy::{eips::BlockId, network::Network, providers::Provider};
+use alloy_primitives::{aliases::I24, Address, U256};
+use derive_more::Deref;
+use uni_obrv::uni_obrv::get_tick_data;
+
+/// A data provider that fetches ticks using a helper contract in a single `eth_call`.
+#[derive(Clone, Debug, PartialEq, Deref)]
+pub struct ObserverTickDataProvider<I = I24> {
+    pub pool: Address,
+    pub tick_lower: I,
+    pub tick_upper: I,
+    pub tick_spacing: I,
+    pub block_id: Option<BlockId>,
+    #[deref]
+    pub ticks: Vec<Tick<I>>,
+}
+
+impl<I: TickIndex> ObserverTickDataProvider<I> {
+    #[inline]
+    pub async fn new<N, P>(
+        pool: Address,
+        provider: P,
+        tick_lower: Option<I>,
+        tick_upper: Option<I>,
+        block_id: Option<BlockId>,
+    ) -> Result<Self, Error>
+    where
+        N: Network,
+        P: Provider<N>,
+    {
+
+        let tick_lower = tick_lower.map_or(MIN_TICK, I::to_i24);
+        let tick_upper = tick_upper.map_or(MAX_TICK, I::to_i24);
+
+        let result = get_tick_data(pool, tick_lower, tick_upper, U256::from(MAX_TICK), provider, Address::ZERO)
+        .await;
+
+    let (ticks, tick_spacing) = match result {
+        Ok((ticks, tick_spacing)) => {
+            let mapped_ticks = ticks
+                .into_iter()
+                .map(|tick| {
+                    Tick::new(
+                        I::from_i24(tick.tick),
+                        tick.liquidity_gross,
+                        tick.liquidity_net,
+                    )
+                })
+                .collect();
+            (mapped_ticks, tick_spacing)
+        }
+        Err(e) => panic!("Valid input test failed: {:?}", e),
+    };
+        Ok(Self {
+            pool,
+            tick_lower: I::from_i24(tick_lower),
+            tick_upper: I::from_i24(tick_upper),
+            tick_spacing: I::from_i24(tick_spacing),
+            block_id,
+            ticks,
+        })
+    }
+}
+
+impl<I: TickIndex> From<ObserverTickDataProvider<I>> for TickListDataProvider<I> {
+    #[inline]
+    fn from(provider: ObserverTickDataProvider<I>) -> Self {
+        assert!(!provider.ticks.is_empty());
+        Self::new(provider.ticks, provider.tick_spacing)
+    }
+}
+
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+    use alloy_primitives::address;
+
+    const TICK_SPACING: i32 = 10;
+
+    #[tokio::test]
+    async fn test_observer_tick_data_provider() -> Result<(), Error> {
+        let provider: ObserverTickDataProvider<i32> = ObserverTickDataProvider::new(
+            address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            PROVIDER.clone(),
+            None,
+            None,
+            BLOCK_ID,
+        )
+        .await?;
+
+        assert!(!provider.ticks.is_empty());
+        provider.ticks.validate_list(TICK_SPACING);
+
+        let tick = provider.get_tick(-92110).await?;
+        assert_eq!(tick.liquidity_gross, 398290794261);
+        assert_eq!(tick.liquidity_net, 398290794261);
+
+                let (tick, initialized) = provider
+            .next_initialized_tick_within_one_word(MIN_TICK_I32 + TICK_SPACING, true, TICK_SPACING)
+            .await?;
+        assert!(initialized);
+        assert_eq!(tick, -887270);
+
+                let (tick, initialized) = provider
+            .next_initialized_tick_within_one_word(0, false, TICK_SPACING)
+            .await?;
+        assert!(initialized);
+        assert_eq!(tick, 100);
+
+        let provider: TickListDataProvider = provider.into();
+        let tick = provider.get_tick(-92110).await?;
+        assert_eq!(tick.liquidity_gross, 398290794261);
+        assert_eq!(tick.liquidity_net, 398290794261);
+
+        Ok(())
+    }
+}

--- a/src/extensions/uni_observer_tick_map_data_provider.rs
+++ b/src/extensions/uni_observer_tick_map_data_provider.rs
@@ -1,0 +1,98 @@
+//! ## Uni Observer Tick Map Data Provider
+//! A data provider that fetches ticks using an [Helper contract](https://github.com/Un4G173N/uni_obrv) in a single `eth_call`.
+
+use crate::prelude::*;
+use alloy::{eips::BlockId, network::Network, providers::Provider};
+use alloy_primitives::{aliases::I24, Address};
+use derive_more::Deref;
+
+/// A data provider that fetches ticks using an helper contract in a single `eth_call`.
+#[derive(Clone, Debug, Deref)]
+pub struct UniObserverTickMapDataProvider<I = I24> {
+    pub pool: Address,
+    pub tick_lower: I,
+    pub tick_upper: I,
+    pub tick_spacing: I,
+    pub block_id: Option<BlockId>,
+    #[deref]
+    pub tick_map: TickMap<I>,
+}
+
+impl<I: TickIndex> UniObserverTickMapDataProvider<I> {
+    #[inline]
+    pub async fn new<N, P>(
+        pool: Address,
+        provider: P,
+        tick_lower: Option<I>,
+        tick_upper: Option<I>,
+        block_id: Option<BlockId>,
+    ) -> Result<Self, Error>
+    where
+        N: Network,
+        P: Provider<N>,
+    {
+        let provider =
+            ObserverTickDataProvider::new(pool, provider, tick_lower, tick_upper, block_id)
+                .await?;
+        Ok(Self {
+            pool,
+            tick_lower: provider.tick_lower,
+            tick_upper: provider.tick_upper,
+            tick_spacing: provider.tick_spacing,
+            block_id,
+            tick_map: TickMap::new(provider.ticks, provider.tick_spacing),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::*;
+    use alloy_primitives::address;
+
+    const TICK_SPACING: i32 = 10;
+
+    #[tokio::test]
+    async fn test_uni_observer_tick_map_data_provider() -> Result<(), Error> {
+        let provider: UniObserverTickMapDataProvider<i32> = UniObserverTickMapDataProvider::new(
+            address!("88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"),
+            PROVIDER.clone(),
+            None,
+            None,
+            BLOCK_ID,
+        )
+        .await?;
+        // [-887270, -92110, 100, 110, 22990, ...]
+
+        let tick = provider.get_tick(-92110).await?;
+        assert_eq!(tick.liquidity_gross, 398290794261);
+        assert_eq!(tick.liquidity_net, 398290794261);
+
+        let (tick, initialized) = provider
+            .next_initialized_tick_within_one_word(MIN_TICK_I32 + TICK_SPACING, true, TICK_SPACING)
+            .await?;
+        assert_eq!(tick, -887270);
+        assert!(initialized);
+
+        let (tick, initialized) = provider
+            .next_initialized_tick_within_one_word(-92120, true, TICK_SPACING)
+            .await?;
+        assert_eq!(tick, -92160);
+        assert!(!initialized);
+
+        let (tick, initialized) = provider
+            .next_initialized_tick_within_one_word(0, false, TICK_SPACING)
+            .await?;
+        assert_eq!(tick, 100);
+        assert!(initialized);
+
+        let (tick, initialized) = provider
+            .next_initialized_tick_within_one_word(110, false, TICK_SPACING)
+            .await?;
+        assert_eq!(tick, 2550);
+        assert!(!initialized);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR introduces a new feature to the uniswap-v3-sdk-rs crate: the ObserverTickDataProvider module, which enables fetching Uniswap V3 pool tick data using an on-chain observer contract via a single eth_call. The module integrates with the uni-obrv crate to query tick data efficiently. 

uni-obrv contract address: 
https://etherscan.io/address/0x4d2c0A1d2d3725618c6799b3DE9FDdEf1d4118B5#code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced two new data providers for Uniswap tick data, enabling efficient retrieval and management of tick information via a single Ethereum call.
  - Added support for both list-based and map-based tick data providers, allowing for flexible tick data access and querying.
- **Tests**
  - Added comprehensive tests to verify correct fetching, validation, and querying of Uniswap tick data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->