### PR TITLE
refactor(multicall): update abi_decode method call

### DIFF
--- a/src/multicall.rs
+++ b/src/multicall.rs
@@ -23,7 +23,7 @@ where
     E: AsRef<[u8]>,
     B: From<Bytes>,
 {
-    IMulticall::multicallCall::abi_decode_validate(encoded.as_ref())
+    IMulticall::multicallCall::abi_decode(encoded.as_ref())
         .map(|decoded| decoded.data.into_iter().map(Into::into).collect())
 }
 


### PR DESCRIPTION
Replaced deprecated `abi_decode_validate` with `abi_decode` for improved functionality. This change enhances the decoding process in the multicall implementation.

Improved method call for better functionality.