### PR TITLE
fix: prevent underflow when accumulating liquidity net in validate_list

### DIFF
--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -43,13 +43,10 @@ impl<I: TickIndex> TickList for [Tick<I>] {
         for i in 1..self.len() {
             assert!(self[i] >= self[i - 1], "SORTED");
         }
-        assert_eq!(
-            self.iter().fold(0_u128, |acc, x| acc
-                .checked_add_signed(x.liquidity_net)
-                .expect("ZERO_NET")),
-            0,
-            "ZERO_NET"
-        );
+        let liquidity_net_sum = self
+            .iter()
+            .fold(0_i128, |acc, x| acc + x.liquidity_net as i128);
+        assert_eq!(liquidity_net_sum, 0, "ZERO_NET");
     }
 
     #[inline]


### PR DESCRIPTION
Fixes: #164 
This PR changes the accumulator type used for summing liquidity net values in validate_list from u128 to i128, in order to prevent an unintended ZERO_NET panic caused by underflow — even when the tick list is otherwise valid.

Underflow can occur when a lower tick index contains a negative liquidity net value, which, when added to the initial u128 accumulator (0), results in None from checked_add_signed and triggers a panic. Using a signed accumulator ensures that both positive and negative values are handled safely during accumulation.