### PR TITLE
test: replace array with `slice::from_ref` and add tick list validati…

### DIFF
--- a/src/staker.rs
+++ b/src/staker.rs
@@ -235,7 +235,7 @@ mod tests {
             amount: Some(uint!(1_U256)),
         };
         let MethodParameters { calldata, value } =
-            collect_rewards(&[INCENTIVE_KEY.clone()], options);
+            collect_rewards(core::slice::from_ref(&INCENTIVE_KEY), options);
         assert_eq!(value, U256::ZERO);
         assert_eq!(
             calldata.to_vec(),
@@ -251,7 +251,7 @@ mod tests {
             amount: None,
         };
         let MethodParameters { calldata, value } =
-            collect_rewards(&[INCENTIVE_KEY.clone()], options);
+            collect_rewards(core::slice::from_ref(&INCENTIVE_KEY), options);
         assert_eq!(value, U256::ZERO);
         assert_eq!(
             calldata.to_vec(),
@@ -278,7 +278,7 @@ mod tests {
     fn test_withdraw_token_succeeds_with_one_key() {
         let options = WITHDRAW_OPTIONS.clone();
         let MethodParameters { calldata, value } =
-            withdraw_token(&[INCENTIVE_KEY.clone()], options);
+            withdraw_token(core::slice::from_ref(&INCENTIVE_KEY), options);
         assert_eq!(value, U256::ZERO);
         assert_eq!(
             calldata.to_vec(),
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn test_encode_deposit_succeeds_single_key() {
-        let deposit = encode_deposit(&[INCENTIVE_KEY.clone()]);
+        let deposit = encode_deposit(core::slice::from_ref(&INCENTIVE_KEY));
         assert_eq!(
             deposit.to_vec(),
             hex!("0000000000000000000000001f9840a85d5af5bf1d1762f925bdaddc4201f9840000000000000000000000004fa63b0dea87d2cd519f3b67a5ddb145779b7bd2000000000000000000000000000000000000000000000000000000000000006400000000000000000000000000000000000000000000000000000000000000c80000000000000000000000000000000000000000000000000000000000000001")
@@ -317,7 +317,7 @@ mod tests {
 
     #[test]
     fn test_safe_transfer_from_succeeds() {
-        let data = encode_deposit(&[INCENTIVE_KEY.clone()]);
+        let data = encode_deposit(core::slice::from_ref(&INCENTIVE_KEY));
         let MethodParameters { calldata, value } =
             safe_transfer_from_parameters(SafeTransferOptions {
                 sender: SENDER,

--- a/src/utils/tick_list.rs
+++ b/src/utils/tick_list.rs
@@ -196,6 +196,41 @@ mod tests {
         fn test_errors_if_ticks_are_not_on_multiples_of_tick_spacing() {
             [HIGH_TICK, LOW_TICK, MID_TICK].validate_list(1337);
         }
+
+        #[test]
+        fn test_u128_max_validates() {
+            // position 0 range [-2, 2), liquidity i128::MAX
+            // position 1 range [-1, 1), liquidity i128::MAX
+            // position 2 range [0, 2), liquidity 1
+            let ticks = [
+                Tick {
+                    index: -2,
+                    liquidity_gross: i128::MAX as u128,
+                    liquidity_net: i128::MAX,
+                },
+                Tick {
+                    index: -1,
+                    liquidity_gross: i128::MAX as u128,
+                    liquidity_net: i128::MAX,
+                },
+                Tick {
+                    index: 0,
+                    liquidity_gross: 1,
+                    liquidity_net: 1, // total liquidity u128::MAX
+                },
+                Tick {
+                    index: 1,
+                    liquidity_gross: i128::MAX as u128,
+                    liquidity_net: -i128::MAX,
+                },
+                Tick {
+                    index: 2,
+                    liquidity_gross: 1 << 127,
+                    liquidity_net: i128::MIN,
+                },
+            ];
+            ticks.validate_list(1);
+        }
     }
 
     #[test]


### PR DESCRIPTION
…on test

Updated calls to use `core::slice::from_ref` instead of arrays for improved clarity and efficiency. Added a new test to validate `u128::MAX` tick liquidity scenarios in `tick_list.rs`.