### PR TITLE
refactor: improve error handling for liquidity overflow

### DIFF
--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -482,19 +482,23 @@ mod tests {
 
     mod constructor {
         use super::*;
+        use uniswap_sdk_core::error::Error as CoreError;
 
         #[test]
-        #[should_panic(expected = "CHAIN_IDS")]
         fn cannot_be_used_for_tokens_on_different_chains() {
             let weth9 = WETH9::default().get(3).unwrap().clone();
-            Pool::new(USDC.clone(), weth9, FeeAmount::MEDIUM, ONE_ETHER, 0).expect("CHAIN_IDS");
+            assert!(matches!(
+                Pool::new(USDC.clone(), weth9, FeeAmount::MEDIUM, ONE_ETHER, 0),
+                Err(Error::Core(CoreError::ChainIdMismatch(1, 3)))
+            ));
         }
 
         #[test]
-        #[should_panic(expected = "ADDRESSES")]
         fn cannot_be_given_two_of_the_same_token() {
-            Pool::new(USDC.clone(), USDC.clone(), FeeAmount::MEDIUM, ONE_ETHER, 0)
-                .expect("ADDRESSES");
+            assert!(matches!(
+                Pool::new(USDC.clone(), USDC.clone(), FeeAmount::MEDIUM, ONE_ETHER, 0),
+                Err(Error::Core(CoreError::EqualAddresses))
+            ));
         }
 
         #[test]
@@ -637,7 +641,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "InvalidToken")]
     fn price_of_throws_if_invalid_token() {
         let pool = Pool::new(
             USDC.clone(),
@@ -647,8 +650,10 @@ mod tests {
             0,
         )
         .unwrap();
-        pool.price_of(&WETH9::default().get(1).unwrap().clone())
-            .unwrap();
+        assert!(matches!(
+            pool.price_of(&WETH9::default().get(1).unwrap().clone()),
+            Err(Error::InvalidToken)
+        ));
     }
 
     #[test]

--- a/src/entities/position.rs
+++ b/src/entities/position.rs
@@ -442,7 +442,7 @@ impl<TP: TickDataProvider> Position<TP> {
         );
         Ok(Self::new(
             pool,
-            liquidity.to_u128().unwrap(),
+            liquidity.to_u128().ok_or(Error::LiquidityOverflow)?,
             tick_lower,
             tick_upper,
         ))
@@ -972,5 +972,23 @@ mod tests {
         let MintAmounts { amount0, amount1 } = position.mint_amounts().unwrap();
         assert_eq!(amount0.to_string(), "120054069145287995769397");
         assert_eq!(amount1.to_string(), "79831926243");
+    }
+
+    #[test]
+    fn from_amount1_liquidity_overflow() {
+        let res = Position::from_amount1(
+            Pool::new(
+                DAI.clone(),
+                WETH.clone(),
+                FeeAmount::LOW,
+                get_sqrt_ratio_at_tick(99200.to_i24()).unwrap(),
+                0,
+            )
+            .unwrap(),
+            99200,
+            99400,
+            U256::from(1000000000000000000_u128),
+        );
+        assert!(matches!(res, Err(Error::LiquidityOverflow)));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use uniswap_sdk_core::error::Error as CoreError;
 
 #[derive(Debug, thiserror::Error)]
 #[cfg_attr(not(feature = "extensions"), derive(Clone, Copy, Hash, PartialEq, Eq))]
+#[non_exhaustive]
 pub enum Error {
     /// Thrown when an error occurs in the core library.
     #[error("{0}")]
@@ -44,6 +45,9 @@ pub enum Error {
 
     #[error("Overflow in price calculation")]
     PriceOverflow,
+
+    #[error("Overflow in liquidity calculation")]
+    LiquidityOverflow,
 
     #[error("Insufficient liquidity")]
     InsufficientLiquidity,

--- a/src/utils/tick_math.rs
+++ b/src/utils/tick_math.rs
@@ -294,15 +294,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "InvalidTick(-887273)")]
     fn get_sqrt_ratio_at_tick_throws_for_tick_too_small() {
-        get_sqrt_ratio_at_tick(MIN_TICK - I24::ONE).unwrap();
+        let result = get_sqrt_ratio_at_tick(MIN_TICK - I24::ONE);
+        assert!(matches!(result, Err(Error::InvalidTick(tick)) if tick == MIN_TICK - I24::ONE));
     }
 
     #[test]
-    #[should_panic(expected = "InvalidTick(887273)")]
     fn get_sqrt_ratio_at_tick_throws_for_tick_too_large() {
-        get_sqrt_ratio_at_tick(MAX_TICK + I24::ONE).unwrap();
+        let result = get_sqrt_ratio_at_tick(MAX_TICK + I24::ONE);
+        assert!(matches!(result, Err(Error::InvalidTick(tick)) if tick == MAX_TICK + I24::ONE));
     }
 
     #[test]


### PR DESCRIPTION
* refactor: improve error handling for liquidity overflow

Introduce `LiquidityOverflow` error for better handling of overflow scenarios in liquidity calculations. Add a corresponding test to ensure accurate error reporting.

* test: replace `should_panic` tests with precise error matching

Updated tests to use `assert!(matches!(...))` for specific error matching instead of `#[should_panic]` annotations. This improves clarity and ensures precise validation of error types and messages in failure scenarios.

* refactor: simplify error matching and make `Error` enum non-exhaustive

Updated tests to use `CoreError` alias for better readability in error matching. Added `#[non_exhaustive]` attribute to `Error` enum for forward compatibility.