### PR TITLE
refactor: centralize reusable constants and provider setups in examples

### DIFF
--- a/examples/common/constants.rs
+++ b/examples/common/constants.rs
@@ -11,8 +11,7 @@ use uniswap_sdk_core::prelude::NONFUNGIBLE_POSITION_MANAGER_ADDRESSES;
 pub const CHAIN_ID: u64 = 1;
 pub const FORK_BLOCK_NUMBER: u64 = 17000000;
 
-pub const BLOCK_ID: Option<BlockId> =
-    Some(BlockId::Number(BlockNumberOrTag::Number(FORK_BLOCK_NUMBER)));
+pub const BLOCK_ID: BlockId = BlockId::Number(BlockNumberOrTag::Number(FORK_BLOCK_NUMBER));
 
 pub static RPC_URL: Lazy<Url> = Lazy::new(|| {
     dotenv::dotenv().ok();

--- a/examples/common/constants.rs
+++ b/examples/common/constants.rs
@@ -1,0 +1,26 @@
+//! Common constants used across examples
+
+use alloy::{
+    eips::{BlockId, BlockNumberOrTag},
+    transports::http::reqwest::Url,
+};
+use alloy_primitives::Address;
+use once_cell::sync::Lazy;
+use uniswap_sdk_core::prelude::NONFUNGIBLE_POSITION_MANAGER_ADDRESSES;
+
+pub const CHAIN_ID: u64 = 1;
+pub const FORK_BLOCK_NUMBER: u64 = 17000000;
+
+pub const BLOCK_ID: Option<BlockId> =
+    Some(BlockId::Number(BlockNumberOrTag::Number(FORK_BLOCK_NUMBER)));
+
+pub static RPC_URL: Lazy<Url> = Lazy::new(|| {
+    dotenv::dotenv().ok();
+    std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap()
+});
+
+pub static NPM_ADDRESS: Lazy<Address> = Lazy::new(|| {
+    *NONFUNGIBLE_POSITION_MANAGER_ADDRESSES
+        .get(&CHAIN_ID)
+        .unwrap()
+});

--- a/examples/common/mod.rs
+++ b/examples/common/mod.rs
@@ -1,0 +1,10 @@
+//! Common utilities and setup code for examples
+
+#![allow(dead_code)]
+pub mod constants;
+pub mod providers;
+pub mod tokens;
+
+pub use constants::*;
+pub use providers::*;
+pub use tokens::*;

--- a/examples/common/providers.rs
+++ b/examples/common/providers.rs
@@ -1,0 +1,23 @@
+//! Common provider setup utilities for examples
+
+use super::constants::{FORK_BLOCK_NUMBER, RPC_URL};
+use alloy::{
+    providers::{Provider, ProviderBuilder},
+    signers::{k256::ecdsa::SigningKey, local::LocalSigner},
+};
+
+pub fn setup_http_provider() -> impl Provider + Clone {
+    ProviderBuilder::new().connect_http(RPC_URL.clone())
+}
+
+pub async fn setup_anvil_fork_provider() -> impl Provider + Clone {
+    ProviderBuilder::new().connect_anvil_with_config(|anvil| {
+        anvil
+            .fork(RPC_URL.clone())
+            .fork_block_number(FORK_BLOCK_NUMBER)
+    })
+}
+
+pub fn random_signer() -> LocalSigner<SigningKey> {
+    alloy::signers::local::PrivateKeySigner::random()
+}

--- a/examples/common/tokens.rs
+++ b/examples/common/tokens.rs
@@ -1,0 +1,18 @@
+//! Common token definitions used across examples
+
+use super::constants::CHAIN_ID;
+use alloy_primitives::{address, Address};
+use once_cell::sync::Lazy;
+use uniswap_sdk_core::{prelude::*, token};
+
+// Token addresses
+pub const WBTC_ADDRESS: Address = address!("2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599");
+pub const USDC_ADDRESS: Address = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+
+pub static WBTC: Lazy<Token> = Lazy::new(|| token!(CHAIN_ID, WBTC_ADDRESS, 8, "WBTC"));
+
+pub static WETH: Lazy<Token> = Lazy::new(|| WETH9::on_chain(CHAIN_ID).unwrap());
+
+pub static USDC: Lazy<Token> = Lazy::new(|| token!(CHAIN_ID, USDC_ADDRESS, 6, "USDC"));
+
+pub static ETHER: Lazy<Ether> = Lazy::new(|| Ether::on_chain(CHAIN_ID));

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -7,31 +7,22 @@
 //! # Note
 //! This example uses mainnet block 17000000 for consistent results
 
-use alloy::{
-    eips::BlockId,
-    providers::{Provider, ProviderBuilder},
-    rpc::types::TransactionRequest,
-    transports::http::reqwest::Url,
-};
+use alloy::{providers::Provider, rpc::types::TransactionRequest};
 use alloy_primitives::U256;
 use alloy_sol_types::SolCall;
-use uniswap_sdk_core::{prelude::*, token};
+use uniswap_sdk_core::prelude::*;
 use uniswap_v3_sdk::prelude::*;
+
+#[path = "common/mod.rs"]
+mod common;
+use common::{setup_http_provider, BLOCK_ID, CHAIN_ID, WBTC, WETH};
 
 #[tokio::main]
 async fn main() {
-    dotenv::dotenv().ok();
-    let rpc_url: Url = std::env::var("MAINNET_RPC_URL").unwrap().parse().unwrap();
-    let provider = ProviderBuilder::new().connect_http(rpc_url);
-    let block_id = BlockId::from(17000000);
-    const CHAIN_ID: u64 = 1;
-    let wbtc = token!(
-        CHAIN_ID,
-        "2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
-        8,
-        "WBTC"
-    );
-    let weth = WETH9::on_chain(CHAIN_ID).unwrap();
+    let provider = setup_http_provider();
+    let block_id = BLOCK_ID.unwrap();
+    let wbtc = WBTC.clone();
+    let weth = WETH.clone();
 
     // Create a pool with a tick map data provider
     let pool = Pool::<EphemeralTickMapDataProvider>::from_pool_key_with_tick_data_provider(

--- a/examples/from_pool_key_with_tick_data_provider.rs
+++ b/examples/from_pool_key_with_tick_data_provider.rs
@@ -20,7 +20,6 @@ use common::{setup_http_provider, BLOCK_ID, CHAIN_ID, WBTC, WETH};
 #[tokio::main]
 async fn main() {
     let provider = setup_http_provider();
-    let block_id = BLOCK_ID.unwrap();
     let wbtc = WBTC.clone();
     let weth = WETH.clone();
 
@@ -32,7 +31,7 @@ async fn main() {
         weth.address(),
         FeeAmount::LOW,
         provider.clone(),
-        Some(block_id),
+        Some(BLOCK_ID),
     )
     .await
     .unwrap();
@@ -48,7 +47,7 @@ async fn main() {
     let tx = TransactionRequest::default()
         .to(*QUOTER_ADDRESSES.get(&CHAIN_ID).unwrap())
         .input(params.calldata.into());
-    let res = provider.call(tx).block(block_id).await.unwrap();
+    let res = provider.call(tx).block(BLOCK_ID).await.unwrap();
     let amount_out =
         IQuoter::quoteExactInputSingleCall::abi_decode_returns_validate(res.as_ref()).unwrap();
     println!("Quoter amount out: {amount_out}");

--- a/examples/swap_router.rs
+++ b/examples/swap_router.rs
@@ -30,7 +30,6 @@ sol! {
 #[tokio::main]
 async fn main() {
     let provider = setup_http_provider();
-    let block_id = BLOCK_ID.unwrap();
     let wbtc = WBTC.clone();
     let eth = ETHER.clone();
 
@@ -42,7 +41,7 @@ async fn main() {
         eth.address(),
         FeeAmount::LOW,
         provider.clone(),
-        Some(block_id),
+        Some(BLOCK_ID),
     )
     .await
     .unwrap();
@@ -55,7 +54,7 @@ async fn main() {
     let tx = TransactionRequest::default()
         .to(*QUOTER_ADDRESSES.get(&CHAIN_ID).unwrap())
         .input(params.calldata.into());
-    let res = provider.call(tx).block(block_id).await.unwrap();
+    let res = provider.call(tx).block(BLOCK_ID).await.unwrap();
     let amount_out =
         IQuoter::quoteExactInputSingleCall::abi_decode_returns_validate(res.as_ref()).unwrap();
     println!("Quoter amount out: {amount_out}");


### PR DESCRIPTION
Introduce a shared `common` module with reusable constants, provider setups, and token definitions for reducing duplication across example files. Simplify examples by replacing inlined constants and provider code with imports from the new module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Shared "common" utilities for examples: centralized chain/block constants, RPC auto-loading, predefined tokens, HTTP and fork provider helpers, and a random signer utility.

- **Refactor**
  - Examples now use shared utilities, removing ad-hoc env/config and hard-coded addresses; standardized chain-aware address lookups and simplified imports; some example flows (pool init) are now async.

- **Chores**
  - Centralized configuration and cleanup across examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->