### PR TITLE
refactor: make `setup_anvil_fork_provider` synchronous and update dep…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "5.2.0"
+version = "5.2.1"
 edition = "2021"
 rust-version = "1.86"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -16,7 +16,7 @@ exclude = [".github", ".gitignore", "rustfmt.toml"]
 all-features = true
 
 [dependencies]
-alloy = { version = "1.0.1", optional = true, default-features = false, features = ["contract"] }
+alloy = { version = "1.0.23", optional = true, default-features = false, features = ["contract"] }
 alloy-primitives = { version = "1.3", default-features = false }
 alloy-sol-types = { version = "1.3", default-features = false }
 anyhow = { version = "1.0", optional = true }
@@ -24,7 +24,7 @@ base64 = { version = "0.22", optional = true, default-features = false }
 derive_more = { version = "2", default-features = false, features = ["deref", "from"] }
 num-integer = { version = "0.1", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-once_cell = { version = "1.20", optional = true, default-features = false, features = ["critical-section"] }
+once_cell = { version = "1.21", optional = true, default-features = false, features = ["critical-section"] }
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
@@ -32,12 +32,12 @@ uniswap-lens = { version = "0.15", optional = true }
 uniswap-sdk-core = "5.2.0"
 
 [dev-dependencies]
-alloy = { version = "1.0.1", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
-criterion = "0.6"
+alloy = { version = "1.0.23", default-features = false, features = ["provider-anvil-node", "reqwest", "signer-local"] }
+criterion = "0.7"
 dotenv = "0.15.0"
-once_cell = "1.20"
-tokio = { version = "1.45", features = ["full"] }
-uniswap_v3_math = "0.6.1"
+once_cell = "1.21"
+tokio = { version = "1.47", features = ["full"] }
+uniswap_v3_math = "0.6.2"
 
 [features]
 default = []

--- a/examples/common/providers.rs
+++ b/examples/common/providers.rs
@@ -10,7 +10,7 @@ pub fn setup_http_provider() -> impl Provider + Clone {
     ProviderBuilder::new().connect_http(RPC_URL.clone())
 }
 
-pub async fn setup_anvil_fork_provider() -> impl Provider + Clone {
+pub fn setup_anvil_fork_provider() -> impl Provider + Clone {
     ProviderBuilder::new().connect_anvil_with_config(|anvil| {
         anvil
             .fork(RPC_URL.clone())

--- a/examples/nonfungible_position_manager.rs
+++ b/examples/nonfungible_position_manager.rs
@@ -20,7 +20,7 @@ async fn main() {
     let npm = *NPM_ADDRESS;
 
     // Create an Anvil fork
-    let provider = setup_anvil_fork_provider().await;
+    let provider = setup_anvil_fork_provider();
     provider.anvil_auto_impersonate_account(true).await.unwrap();
     let account: LocalSigner<SigningKey> = random_signer();
     provider

--- a/examples/self_permit.rs
+++ b/examples/self_permit.rs
@@ -35,7 +35,7 @@ sol! {
 #[tokio::main]
 async fn main() {
     // Create an Anvil fork
-    let provider = setup_anvil_fork_provider().await;
+    let provider = setup_anvil_fork_provider();
     provider.anvil_auto_impersonate_account(true).await.unwrap();
 
     let usdc = USDC.clone();

--- a/examples/swap_router.rs
+++ b/examples/swap_router.rs
@@ -60,7 +60,7 @@ async fn main() {
     println!("Quoter amount out: {amount_out}");
 
     // Create an Anvil fork
-    let provider = setup_anvil_fork_provider().await;
+    let provider = setup_anvil_fork_provider();
     let account = provider.get_accounts().await.unwrap()[0];
 
     // Build the swap transaction

--- a/src/extensions/pool.rs
+++ b/src/extensions/pool.rs
@@ -5,11 +5,7 @@
 
 use crate::prelude::*;
 use alloc::{string::ToString, vec, vec::Vec};
-use alloy::{
-    eips::{BlockId, BlockNumberOrTag},
-    network::Network,
-    providers::Provider,
-};
+use alloy::{eips::BlockId, network::Network, providers::Provider};
 use alloy_primitives::{Address, ChainId, B256};
 use uniswap_lens::{
     bindings::{
@@ -63,7 +59,7 @@ impl Pool {
         N: Network,
         P: Provider<N>,
     {
-        let block_id = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let block_id = block_id.unwrap_or(BlockId::latest());
         let pool_contract = get_pool_contract(factory, token_a, token_b, fee, provider.root());
         let token_a_contract = IERC20Metadata::new(token_a, provider.root());
         let token_b_contract = IERC20Metadata::new(token_b, provider.root());

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -6,7 +6,7 @@
 use crate::prelude::{Error, *};
 use alloc::string::ToString;
 use alloy::{
-    eips::{BlockId, BlockNumberOrTag},
+    eips::BlockId,
     network::Network,
     providers::Provider,
     transports::{TransportError, TransportErrorKind},
@@ -57,7 +57,7 @@ where
     N: Network,
     P: Provider<N>,
 {
-    let block_id_ = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+    let block_id_ = block_id.unwrap_or(BlockId::latest());
     let npm_contract =
         get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.root());
     let multicall = provider
@@ -266,7 +266,7 @@ where
     N: Network,
     P: Provider<N>,
 {
-    let block_id_ = block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+    let block_id_ = block_id.unwrap_or(BlockId::latest());
     let npm_contract =
         get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.root());
     let multicall = provider
@@ -351,7 +351,7 @@ where
 {
     let uri = get_nonfungible_position_manager_contract(nonfungible_position_manager, provider)
         .tokenURI(token_id)
-        .block(block_id.unwrap_or(BlockId::Number(BlockNumberOrTag::Latest)))
+        .block(block_id.unwrap_or(BlockId::latest()))
         .call()
         .await?;
     let json_uri = base64::Engine::decode(
@@ -467,7 +467,7 @@ where
 mod tests {
     use super::*;
     use crate::tests::PROVIDER;
-    use alloy::providers::MulticallBuilder;
+    use alloy::{eips::BlockNumberOrTag, providers::MulticallBuilder};
     use alloy_primitives::{address, uint};
     use fastnum::decimal::Context;
 

--- a/src/extensions/position.rs
+++ b/src/extensions/position.rs
@@ -57,7 +57,7 @@ where
     N: Network,
     P: Provider<N>,
 {
-    let block_id_ = block_id.unwrap_or(BlockId::latest());
+    let block_id = block_id.unwrap_or(BlockId::latest());
     let npm_contract =
         get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.root());
     let multicall = provider
@@ -75,7 +75,7 @@ where
             liquidity,
             ..
         },
-    ) = multicall.block(block_id_).aggregate().await?;
+    ) = multicall.block(block_id).aggregate().await?;
     let pool = Pool::from_pool_key(
         chain_id,
         factory,
@@ -83,7 +83,7 @@ where
         token1,
         fee.into(),
         provider,
-        block_id,
+        Some(block_id),
     )
     .await?;
     Ok(Position::new(
@@ -266,14 +266,14 @@ where
     N: Network,
     P: Provider<N>,
 {
-    let block_id_ = block_id.unwrap_or(BlockId::latest());
+    let block_id = block_id.unwrap_or(BlockId::latest());
     let npm_contract =
         get_nonfungible_position_manager_contract(nonfungible_position_manager, provider.root());
     let multicall = provider
         .multicall()
         .add(npm_contract.factory())
         .add(npm_contract.positions(token_id));
-    let (factory, position) = multicall.block(block_id_).aggregate().await?;
+    let (factory, position) = multicall.block(block_id).aggregate().await?;
     let pool_contract = get_pool_contract(
         factory,
         position.token0,
@@ -289,7 +289,7 @@ where
         .add(pool_contract.ticks(position.tickLower))
         .add(pool_contract.ticks(position.tickUpper));
     let (slot0, fee_growth_global_0x128, fee_growth_global_1x128, tick_info_lower, tick_info_upper) =
-        multicall.block(block_id_).aggregate().await?;
+        multicall.block(block_id).aggregate().await?;
     let tick = slot0.tick;
     let fee_growth_outside_0x128_lower = tick_info_lower.feeGrowthOutside0X128;
     let fee_growth_outside_1x128_lower = tick_info_lower.feeGrowthOutside1X128;

--- a/src/extensions/simple_tick_data_provider.rs
+++ b/src/extensions/simple_tick_data_provider.rs
@@ -3,7 +3,7 @@
 
 use crate::prelude::*;
 use alloy::{
-    eips::{BlockId, BlockNumberOrTag},
+    eips::BlockId,
     network::{Ethereum, Network},
     providers::Provider,
     sol,
@@ -77,9 +77,7 @@ where
 
     #[inline]
     async fn get_word(&self, index: Self::Index) -> Result<U256, Error> {
-        let block_id = self
-            .block_id
-            .unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let block_id = self.block_id.unwrap_or(BlockId::latest());
         let word = self
             .pool
             .tickBitmap(index.to_i24().as_i16())
@@ -100,9 +98,7 @@ where
 
     #[inline]
     async fn get_tick(&self, index: Self::Index) -> Result<Tick<Self::Index>, Error> {
-        let block_id = self
-            .block_id
-            .unwrap_or(BlockId::Number(BlockNumberOrTag::Latest));
+        let block_id = self.block_id.unwrap_or(BlockId::latest());
         let tick = self
             .pool
             .ticks(index.to_i24())


### PR DESCRIPTION
…endencies

- Changed `setup_anvil_fork_provider` to a synchronous function for improved simplicity and performance in examples.
- Updated dependencies (`alloy`, `once_cell`, `criterion`, `tokio`, `uniswap_v3_math`) and incremented package version to 5.2.1.
- Simplified usage of `BlockId::latest()` by removing `BlockNumberOrTag` type where unnecessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Example setups: provider initialization is now synchronous (no await required).
  - Extensions: unspecified block selection now defaults to the latest block consistently.

- Chores
  - Package version bumped to 5.2.1.
  - Updated dependencies and dev-dependencies for compatibility and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->