### PR TITLE
refactor: improve benchmarking with edge cases and comparison groups

### DIFF
--- a/benches/swap_math.rs
+++ b/benches/swap_math.rs
@@ -1,6 +1,7 @@
-use alloy_primitives::{aliases::U24, keccak256, I256, U160, U256};
+use alloy_primitives::{aliases::U24, keccak256, uint, I256, U160, U256};
 use alloy_sol_types::SolValue;
-use criterion::{criterion_group, criterion_main, Criterion};
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use uniswap_v3_math::swap_math;
 use uniswap_v3_sdk::prelude::*;
 
@@ -14,7 +15,7 @@ fn pseudo_random_128(seed: u64) -> u128 {
 }
 
 fn generate_inputs() -> Vec<(U160, U160, u128, I256, U24)> {
-    (0u64..100)
+    let mut inputs = (0u64..100)
         .map(|i| {
             (
                 U160::saturating_from(pseudo_random(i)),
@@ -24,12 +25,62 @@ fn generate_inputs() -> Vec<(U160, U160, u128, I256, U24)> {
                 U24::from(i),
             )
         })
-        .collect()
+        .collect::<Vec<_>>();
+
+    // Add edge cases
+    inputs.extend([
+        (
+            U160::MIN,
+            U160::MIN,
+            1,
+            I256::from_raw(uint!(1_U256)),
+            U24::from(500),
+        ), // 0.05%
+        (
+            U160::MAX,
+            U160::MAX,
+            u128::MAX,
+            I256::from_raw(U256::MAX - uint!(1_U256)),
+            U24::from(3000),
+        ), // 0.3%
+        (
+            U160::from(Q96),
+            U160::from(Q96),
+            1000000,
+            I256::ZERO,
+            U24::from(10000),
+        ), // 1%
+    ]);
+
+    inputs
 }
 
-fn compute_swap_step_benchmark(c: &mut Criterion) {
-    let inputs = generate_inputs();
-    c.bench_function("compute_swap_step", |b| {
+type SdkSwapInputs = Vec<(U160, U160, u128, I256, U24)>;
+type RefSwapInputs = Vec<(U256, U256, u128, I256, u32)>;
+
+fn generate_inputs_with_ref() -> (SdkSwapInputs, RefSwapInputs) {
+    let sdk_inputs = generate_inputs();
+    let ref_inputs = sdk_inputs
+        .iter()
+        .map(|(a, b, c, d, e)| {
+            (
+                U256::from(*a),
+                U256::from(*b),
+                *c,
+                *d,
+                e.into_limbs()[0] as u32,
+            )
+        })
+        .collect();
+    (sdk_inputs, ref_inputs)
+}
+
+fn compute_swap_step_comparison(c: &mut Criterion) {
+    let (sdk_inputs, ref_inputs) = generate_inputs_with_ref();
+    let mut group = c.benchmark_group("compute_swap_step");
+    group.throughput(Throughput::Elements(sdk_inputs.len() as u64));
+
+    group.bench_function("sdk", |b| {
         b.iter(|| {
             for (
                 sqrt_ratio_current_x96,
@@ -37,26 +88,20 @@ fn compute_swap_step_benchmark(c: &mut Criterion) {
                 liquidity,
                 amount_remaining,
                 fee_pips,
-            ) in &inputs
+            ) in &sdk_inputs
             {
-                let _ = compute_swap_step(
+                let _ = black_box(compute_swap_step(
                     *sqrt_ratio_current_x96,
                     *sqrt_ratio_target_x96,
                     *liquidity,
                     *amount_remaining,
                     *fee_pips,
-                );
+                ));
             }
         })
     });
-}
 
-fn compute_swap_step_benchmark_ref(c: &mut Criterion) {
-    let inputs = generate_inputs()
-        .into_iter()
-        .map(|(a, b, c, d, e)| (U256::from(a), U256::from(b), c, d, e))
-        .collect::<Vec<_>>();
-    c.bench_function("compute_swap_step_ref", |b| {
+    group.bench_function("reference", |b| {
         b.iter(|| {
             for (
                 sqrt_ratio_current_x96,
@@ -64,23 +109,21 @@ fn compute_swap_step_benchmark_ref(c: &mut Criterion) {
                 liquidity,
                 amount_remaining,
                 fee_pips,
-            ) in &inputs
+            ) in &ref_inputs
             {
-                let _ = swap_math::compute_swap_step(
+                let _ = black_box(swap_math::compute_swap_step(
                     *sqrt_ratio_current_x96,
                     *sqrt_ratio_target_x96,
                     *liquidity,
                     *amount_remaining,
-                    fee_pips.into_limbs()[0] as u32,
-                );
+                    *fee_pips,
+                ));
             }
         })
     });
+
+    group.finish();
 }
 
-criterion_group!(
-    benches,
-    compute_swap_step_benchmark,
-    compute_swap_step_benchmark_ref,
-);
+criterion_group!(benches, compute_swap_step_comparison,);
 criterion_main!(benches);

--- a/benches/tick_math.rs
+++ b/benches/tick_math.rs
@@ -1,59 +1,95 @@
 use alloy_primitives::{aliases::I24, U160, U256};
-use core::ops::Shl;
-use criterion::{criterion_group, criterion_main, Criterion};
+use core::{hint::black_box, ops::Shl};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use uniswap_v3_math::tick_math;
 use uniswap_v3_sdk::prelude::*;
 
-fn generate_inputs() -> Vec<I24> {
-    (-128..=128).map(|i| I24::try_from(i).unwrap()).collect()
+fn generate_tick_inputs() -> Vec<I24> {
+    let mut inputs = (-128..=128)
+        .map(|i| I24::try_from(i).unwrap())
+        .collect::<Vec<_>>();
+
+    // Add edge cases
+    inputs.extend([
+        MIN_TICK,
+        MAX_TICK,
+        I24::ZERO,
+        I24::try_from(1000).unwrap(),
+        I24::try_from(-1000).unwrap(),
+    ]);
+
+    inputs
 }
 
-fn get_sqrt_ratio_at_tick_benchmark(c: &mut Criterion) {
-    let inputs = generate_inputs();
-    c.bench_function("get_sqrt_ratio_at_tick", |b| {
+fn generate_sqrt_ratio_inputs() -> Vec<U160> {
+    let mut inputs = (33u8..=159)
+        .map(|i| U160::from(1).shl(i))
+        .collect::<Vec<_>>();
+
+    // Add edge cases
+    inputs.extend([MIN_SQRT_RATIO, MAX_SQRT_RATIO, U160::from(Q96)]);
+
+    inputs
+}
+
+fn generate_sqrt_ratio_inputs_with_ref() -> (Vec<U160>, Vec<U256>) {
+    let sdk_inputs = generate_sqrt_ratio_inputs();
+    let ref_inputs = sdk_inputs.iter().map(|&x| U256::from(x)).collect();
+    (sdk_inputs, ref_inputs)
+}
+
+fn get_sqrt_ratio_at_tick_comparison(c: &mut Criterion) {
+    let inputs = generate_tick_inputs();
+    let mut group = c.benchmark_group("get_sqrt_ratio_at_tick");
+    group.throughput(Throughput::Elements(inputs.len() as u64));
+
+    group.bench_function("sdk", |b| {
         b.iter(|| {
             for i in &inputs {
-                let _ = get_sqrt_ratio_at_tick(*i);
+                let _ = black_box(get_sqrt_ratio_at_tick(*i));
             }
         })
     });
-}
 
-fn get_sqrt_ratio_at_tick_benchmark_ref(c: &mut Criterion) {
-    c.bench_function("get_sqrt_ratio_at_tick_ref", |b| {
+    // Reference uses i32 directly, so convert I24 to i32
+    group.bench_function("reference", |b| {
         b.iter(|| {
-            for i in -128..=128 {
-                let _ = tick_math::get_sqrt_ratio_at_tick(i);
+            for i in &inputs {
+                let _ = black_box(tick_math::get_sqrt_ratio_at_tick(i.as_i32()));
             }
         })
     });
+
+    group.finish();
 }
 
-fn get_tick_at_sqrt_ratio_benchmark(c: &mut Criterion) {
-    c.bench_function("get_tick_at_sqrt_ratio", |b| {
-        b.iter(|| {
-            for i in 33u8..=159 {
-                let _ = get_tick_at_sqrt_ratio(U160::from(1).shl(i));
-            }
-        });
-    });
-}
+fn get_tick_at_sqrt_ratio_comparison(c: &mut Criterion) {
+    let (sdk_inputs, ref_inputs) = generate_sqrt_ratio_inputs_with_ref();
+    let mut group = c.benchmark_group("get_tick_at_sqrt_ratio");
+    group.throughput(Throughput::Elements(sdk_inputs.len() as u64));
 
-fn get_tick_at_sqrt_ratio_benchmark_ref(c: &mut Criterion) {
-    c.bench_function("get_tick_at_sqrt_ratio_ref", |b| {
+    group.bench_function("sdk", |b| {
         b.iter(|| {
-            for i in 33u8..=159 {
-                let _ = tick_math::get_tick_at_sqrt_ratio(U256::from(1).shl(i));
+            for sqrt_ratio in &sdk_inputs {
+                let _ = black_box(get_tick_at_sqrt_ratio(*sqrt_ratio));
             }
-        });
+        })
     });
+
+    group.bench_function("reference", |b| {
+        b.iter(|| {
+            for sqrt_ratio in &ref_inputs {
+                let _ = black_box(tick_math::get_tick_at_sqrt_ratio(*sqrt_ratio));
+            }
+        })
+    });
+
+    group.finish();
 }
 
 criterion_group!(
     benches,
-    get_sqrt_ratio_at_tick_benchmark,
-    get_sqrt_ratio_at_tick_benchmark_ref,
-    get_tick_at_sqrt_ratio_benchmark,
-    get_tick_at_sqrt_ratio_benchmark_ref
+    get_sqrt_ratio_at_tick_comparison,
+    get_tick_at_sqrt_ratio_comparison
 );
 criterion_main!(benches);


### PR DESCRIPTION
- Added edge cases to benchmark inputs across modules (`sqrt_price_math`, `tick_math`, `swap_math`, `bit_math`) to enhance robustness.
- Introduced SDK vs. reference comparison groups using `Criterion::benchmark_group` for better performance analysis.
- Optimized benchmarks by leveraging `black_box` to prevent compiler optimizations and added `Throughput` for more informative results.
- Reorganized and replaced individual benchmark functions with grouped comparisons for clarity and maintainability.