### PR TITLE
chore: bump uniswap-sdk-core to 6.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "5.3.1"
+version = "6.0.0"
 edition = "2021"
 rust-version = "1.88"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -29,7 +29,7 @@ regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
 uniswap-lens = { version = "0.15", optional = true }
-uniswap-sdk-core = "5.3.0"
+uniswap-sdk-core = "6.0.0"
 
 [dev-dependencies]
 alloy = { version = "1.1", default-features = false, features = ["provider-anvil-node", "reqwest-rustls-tls", "signer-local"] }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The current MSRV (minimum supported Rust version) is 1.88.
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "5.3.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "6.0.0", features = ["extensions", "std"] }
 ```
 
 ### Usage

--- a/src/entities/pool.rs
+++ b/src/entities/pool.rs
@@ -579,7 +579,10 @@ mod tests {
             USDC.clone(),
             DAI.clone(),
             FeeAmount::LOW,
-            encode_sqrt_ratio_x96(101e6 as u128, 100e18 as u128),
+            encode_sqrt_ratio_x96(
+                BigInt::from_u128(101e6 as u128).unwrap(),
+                BigInt::from_u128(100e18 as u128).unwrap(),
+            ),
             0,
         )
         .unwrap();
@@ -588,7 +591,10 @@ mod tests {
             DAI.clone(),
             USDC.clone(),
             FeeAmount::LOW,
-            encode_sqrt_ratio_x96(101e6 as u128, 100e18 as u128),
+            encode_sqrt_ratio_x96(
+                BigInt::from_u128(101e6 as u128).unwrap(),
+                BigInt::from_u128(100e18 as u128).unwrap(),
+            ),
             0,
         )
         .unwrap();
@@ -601,7 +607,10 @@ mod tests {
             USDC.clone(),
             DAI.clone(),
             FeeAmount::LOW,
-            encode_sqrt_ratio_x96(101e6 as u128, 100e18 as u128),
+            encode_sqrt_ratio_x96(
+                BigInt::from_u128(101e6 as u128).unwrap(),
+                BigInt::from_u128(100e18 as u128).unwrap(),
+            ),
             0,
         )
         .unwrap();
@@ -613,7 +622,10 @@ mod tests {
             DAI.clone(),
             USDC.clone(),
             FeeAmount::LOW,
-            encode_sqrt_ratio_x96(101e6 as u128, 100e18 as u128),
+            encode_sqrt_ratio_x96(
+                BigInt::from_u128(101e6 as u128).unwrap(),
+                BigInt::from_u128(100e18 as u128).unwrap(),
+            ),
             0,
         )
         .unwrap();

--- a/src/entities/position.rs
+++ b/src/entities/position.rs
@@ -1,6 +1,5 @@
 use crate::prelude::{Error, *};
 use alloy_primitives::{U160, U256};
-use num_traits::ToPrimitive;
 use uniswap_sdk_core::prelude::*;
 
 /// Represents a position on a Uniswap V3 Pool
@@ -440,7 +439,7 @@ impl<TP: TickDataProvider> Position<TP> {
         );
         Ok(Self::new(
             pool,
-            liquidity.to_u128().ok_or(Error::LiquidityOverflow)?,
+            liquidity.to_u128().map_err(|_| Error::LiquidityOverflow)?,
             tick_lower,
             tick_upper,
         ))

--- a/src/entities/trade.rs
+++ b/src/entities/trade.rs
@@ -817,7 +817,6 @@ mod tests {
     use super::*;
     use crate::{create_route, currency_amount, tests::*, trade_from_route};
     use num_integer::Roots;
-    use num_traits::ToPrimitive;
     use once_cell::sync::Lazy;
     use tokio::sync::OnceCell;
 

--- a/src/extensions/price_tick_conversions.rs
+++ b/src/extensions/price_tick_conversions.rs
@@ -67,9 +67,7 @@ where
         None => (price, ""),
     };
     let decimals = fraction.len();
-    let without_decimals: BigInt = [whole, fraction]
-        .concat()
-        .parse()
+    let without_decimals: BigInt = BigInt::from_str(&[whole, fraction].concat())
         .map_err(|e| anyhow::anyhow!("Invalid price string: {}", e))?;
     let numerator = without_decimals * BigInt::from(10).pow(quote_token.decimals() as u32);
     let denominator = BigInt::from(10).pow(decimals as u32 + base_token.decimals() as u32);

--- a/src/nonfungible_position_manager.rs
+++ b/src/nonfungible_position_manager.rs
@@ -1,7 +1,6 @@
 use crate::prelude::{Error, *};
 use alloy_primitives::{Bytes, Signature, B256, U256};
 use alloy_sol_types::{eip712_domain, Eip712Domain, SolCall, SolStruct};
-use num_traits::ToPrimitive;
 use uniswap_sdk_core::prelude::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -327,10 +326,11 @@ where
             position.pool.sqrt_ratio_x96,
             position.pool.liquidity,
         )?,
-        (options.liquidity_percentage.clone() * Percent::new(position.liquidity, 1))
-            .quotient()
-            .to_u128()
-            .unwrap(),
+        (options.liquidity_percentage.clone()
+            * Percent::new(BigInt::from_u128(position.liquidity).unwrap(), 1))
+        .quotient()
+        .to_u128()
+        .unwrap(),
         position.tick_lower.try_into().unwrap(),
         position.tick_upper.try_into().unwrap(),
     );

--- a/src/utils/encode_sqrt_ratio_x96.rs
+++ b/src/utils/encode_sqrt_ratio_x96.rs
@@ -1,7 +1,8 @@
 use alloy_primitives::Uint;
-use bnum::cast::CastFrom;
-use fastnum::I1024;
-use uniswap_sdk_core::prelude::*;
+use uniswap_sdk_core::prelude::{
+    fastnum::{Cast, TryCast, I1024},
+    *,
+};
 
 /// Returns the sqrt ratio as a Q64.96 corresponding to a given ratio of `amount1` and `amount0`.
 ///
@@ -18,9 +19,10 @@ pub fn encode_sqrt_ratio_x96<const BITS: usize, const LIMBS: usize>(
     amount1: impl Into<BigInt>,
     amount0: impl Into<BigInt>,
 ) -> Uint<BITS, LIMBS> {
-    let numerator = I1024::cast_from(amount1.into()) << 192;
-    let denominator = I1024::cast_from(amount0.into());
-    Uint::from_big_int(sqrt(BigInt::cast_from(numerator / denominator)).unwrap())
+    let numerator: I1024 = amount1.into().cast();
+    let denominator: I1024 = amount0.into().cast();
+    let ratio: BigInt = ((numerator << 192_u32) / denominator).try_cast().unwrap();
+    Uint::from_big_int(sqrt(ratio).unwrap())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Update for fastnum 0.7 API changes:
- Use Cast and TryCast traits instead of bnum::cast::CastFrom
- Use BigInt::from_u128() and BigInt::from_str() for conversions
- Handle to_u128() returning Result instead of Option

BREAKING CHANGE: uniswap-sdk-core 6.0.0 uses fastnum 0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped package to 6.0.0 and updated core SDK dependency.
  * Updated README examples to reflect new dependency version.

* **Refactor**
  * Internal numeric and type-handling updated for more consistent arithmetic and error paths.
  * Tests adjusted to align with revised numeric handling.

* **Style**
  * Removed unused imports and streamlined error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->