### PR TITLE
chore: bump package versions for uniswap-lens, criterion, and SDK to …

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uniswap-v3-sdk"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2024"
 rust-version = "1.88"
 authors = ["Shuhui Luo <twitter.com/aureliano_law>"]
@@ -28,12 +28,12 @@ once_cell = { version = "1.21", optional = true, default-features = false, featu
 regex = { version = "1.11", optional = true }
 serde_json = { version = "1.0", optional = true, default-features = false }
 thiserror = { version = "2", default-features = false }
-uniswap-lens = { version = "0.15", optional = true }
+uniswap-lens = { version = "1.0.0", optional = true }
 uniswap-sdk-core = "6.0.0"
 
 [dev-dependencies]
 alloy = { version = "1.1", default-features = false, features = ["provider-anvil-node", "reqwest-rustls-tls", "signer-local"] }
-criterion = "0.7"
+criterion = "0.8"
 dotenv = "0.15.0"
 once_cell = "1.21"
 tokio = { version = "1.47", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ incompatible-rust-versions = "fallback"
 Add the following to your `Cargo.toml` file:
 
 ```toml
-uniswap-v3-sdk = { version = "6.1.0", features = ["extensions", "std"] }
+uniswap-v3-sdk = { version = "6.2.0", features = ["extensions", "std"] }
 ```
 
 ### Usage


### PR DESCRIPTION
…6.2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation examples to reflect version 6.2.0

* **Chores**
  * Bumped package version to 6.2.0
  * Upgraded uniswap-lens optional dependency from 0.15 to 1.0.0
  * Upgraded criterion development dependency from 0.7 to 0.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->